### PR TITLE
Show example of how to remove unnecessary collect-time for default dependencies

### DIFF
--- a/src/features/react-hooks-context-mvvm/Todos/models/todos-model.test.tsx
+++ b/src/features/react-hooks-context-mvvm/Todos/models/todos-model.test.tsx
@@ -32,8 +32,12 @@ describe("Add todos (command)", () => {
     await waitFor(() => result.current.addTodo("Paint house"));
 
     // assert
+    await waitFor(() =>
+      expect(result.current.todos).toEqual([
+        { id: "abc", text: "Paint house" },
+      ]),
+    );
     expect(mockDependencies.generateId).toHaveBeenCalledOnce();
-    expect(result.current.todos).toEqual([{ id: "abc", text: "Paint house" }]);
   });
 
   it("should work as expected when adding multiple todos", async () => {

--- a/src/features/react-hooks-context/Todos/model.test.tsx
+++ b/src/features/react-hooks-context/Todos/model.test.tsx
@@ -29,8 +29,13 @@ describe("Add todos (command)", () => {
     await waitFor(() => result.current.addTodo("Paint house"));
 
     // assert
+    await waitFor(() =>
+      expect(result.current.todos).toEqual([
+        { id: "abc", text: "Paint house" },
+      ]),
+    );
+
     expect(mockDependencies.generateId).toHaveBeenCalledOnce();
-    expect(result.current.todos).toEqual([{ id: "abc", text: "Paint house" }]);
   });
 
   it("should work as expected when adding multiple todos", async () => {
@@ -60,8 +65,6 @@ describe("Add todos (command)", () => {
     await waitFor(() => result.current.addTodo("Wash car"));
 
     // assert
-    expect(mockDependencies.generateId).toHaveBeenCalledTimes(3);
-
     await waitFor(() =>
       expect(result.current.todos).toEqual([
         { id: "abc", text: "Paint house" },
@@ -69,6 +72,8 @@ describe("Add todos (command)", () => {
         { id: "abc", text: "Wash car" },
       ]),
     );
+
+    expect(mockDependencies.generateId).toHaveBeenCalledTimes(3);
   });
 
   it("should fail validation when adding empty todo", async () => {
@@ -96,8 +101,8 @@ describe("Add todos (command)", () => {
     await waitFor(() => result.current.addTodo(""));
 
     // assert
+    await waitFor(() => expect(result.current.todos).toEqual([]));
     expect(mockDependencies.generateId).not.toHaveBeenCalled();
-    expect(result.current.todos).toEqual([]);
   });
 });
 

--- a/src/features/signals-mvvm-commands/TasksContext/containers/TaskItem/TaskItem.view.context.ts
+++ b/src/features/signals-mvvm-commands/TasksContext/containers/TaskItem/TaskItem.view.context.ts
@@ -1,5 +1,8 @@
 import React from "react";
-import { useTaskItemViewModel } from "./TaskItem.view-model";
+
+import defaultDependencies, {
+  TaskItemDependencies,
+} from "./TaskItem.view.dependencies";
 
 /**
  * The context can be used to inject any kind of
@@ -18,13 +21,7 @@ import { useTaskItemViewModel } from "./TaskItem.view-model";
  * The interfaces of the components also become much simpler.
  */
 
-export interface TaskItemContextInterface {
-  useTaskItemViewModel: typeof useTaskItemViewModel;
-}
-
-export const defaultValue: TaskItemContextInterface = {
-  useTaskItemViewModel,
-};
+export const defaultValue: TaskItemDependencies = { ...defaultDependencies };
 
 export const TaskItemContext =
-  React.createContext<TaskItemContextInterface>(defaultValue);
+  React.createContext<TaskItemDependencies>(defaultValue);

--- a/src/features/signals-mvvm-commands/TasksContext/containers/TaskItem/TaskItem.view.dependencies.ts
+++ b/src/features/signals-mvvm-commands/TasksContext/containers/TaskItem/TaskItem.view.dependencies.ts
@@ -1,0 +1,11 @@
+import { useTaskItemViewModel } from "./TaskItem.view-model";
+
+export interface TaskItemDependencies {
+  useTaskItemViewModel: typeof useTaskItemViewModel;
+}
+
+const defaultDependencies: TaskItemDependencies = {
+  useTaskItemViewModel,
+};
+
+export default defaultDependencies;

--- a/src/features/signals-mvvm-commands/TasksContext/containers/TaskItem/TaskItem.view.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksContext/containers/TaskItem/TaskItem.view.test.tsx
@@ -1,11 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import { TaskItem } from "./TaskItem.view";
 import { Task } from "../../types";
-import {
-  TaskItemContext,
-  TaskItemContextInterface,
-} from "./TaskItem.view.context";
+import { TaskItemContext } from "./TaskItem.view.context";
 import userEvent from "@testing-library/user-event";
+import { TaskItemDependencies } from "./TaskItem.view.dependencies";
+
+/**
+ * Remove default dependencies to avoid unnecessary collect-time
+ * and other side-effects caused from importing them
+ */
+vi.mock("./TaskItem.view.dependencies", () => ({ default: {} }));
 
 describe("TaskItem", () => {
   it("Renders correctly when user is loaded", () => {
@@ -16,7 +20,7 @@ describe("TaskItem", () => {
       ownerId: "user-1",
     };
 
-    const taskItemDependencies: TaskItemContextInterface = {
+    const taskItemDependencies: TaskItemDependencies = {
       useTaskItemViewModel: () => ({
         user: {
           id: "user-1",
@@ -46,7 +50,7 @@ describe("TaskItem", () => {
       ownerId: "user-1",
     };
 
-    const taskItemDependencies: TaskItemContextInterface = {
+    const taskItemDependencies: TaskItemDependencies = {
       useTaskItemViewModel: () => ({
         user: undefined,
         deleteTask: vi.fn(),
@@ -74,7 +78,7 @@ describe("TaskItem", () => {
       ownerId: "user-1",
     };
 
-    const taskItemDependencies: TaskItemContextInterface = {
+    const taskItemDependencies: TaskItemDependencies = {
       useTaskItemViewModel: () => ({
         user: {
           id: "user-1",

--- a/src/features/signals-mvvm-commands/TasksContextDiContainers/views/App/App.view-model.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksContextDiContainers/views/App/App.view-model.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { useAppViewModel } from "./App.view-model";
+import { CommandsDependencies, useAppViewModel } from "./App.view-model";
 import {
   AppViewModelContext,
   AppViewModelContextInterface,
@@ -8,10 +8,7 @@ import { ISelectedFiltersModel } from "../../models/selected-filters.model";
 import { ITasksModel } from "../../models/tasks.model";
 import { IUsersModel } from "../../models/users.model";
 import { QueryClientProvider } from "@tanstack/react-query";
-import {
-  CommandsContext,
-  CommandsContextInterface,
-} from "../../providers/commands.provider";
+import { CommandsContext } from "../../providers/commands.provider";
 import { createQueryClient } from "../../utils/create-query-client";
 
 describe("useAppViewModel", () => {
@@ -29,10 +26,9 @@ describe("useAppViewModel", () => {
       createUsersModel: vi.fn(() => usersModel),
     };
 
-    const commands: CommandsContextInterface = {
+    const commands: CommandsDependencies = {
       addTaskCommand: vi.fn(),
       deleteTaskCommand: vi.fn(),
-      getUserCommand: vi.fn(),
       listTasksCommand: vi.fn(),
       listUsersCommand: vi.fn(),
     };

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/providers/commands.provider.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/providers/commands.provider.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook } from "@testing-library/react";
+import {
+  CommandsContext,
+  CommandsContextInterface,
+  useCommands,
+} from "./commands.provider";
+
+describe("useCommands", () => {
+  it("should work if commands are provided", async () => {
+    // arrange
+    const commands: CommandsContextInterface = {
+      addTaskCommand: vi.fn(),
+      deleteTaskCommand: vi.fn(),
+      getUserCommand: vi.fn(),
+      listTasksCommand: vi.fn(),
+      listUsersCommand: vi.fn(),
+    };
+
+    const wrapper: React.FC<{
+      children?: React.ReactNode;
+    }> = ({ children }) => (
+      <CommandsContext.Provider value={commands}>
+        {children}
+      </CommandsContext.Provider>
+    );
+
+    const { result } = renderHook(() => useCommands(), { wrapper });
+
+    expect(result.current).toEqual(commands);
+  });
+
+  it("should fail if commands are not provided", async () => {
+    // arrange
+    expect(() => renderHook(() => useCommands())).toThrowError();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/providers/commands.provider.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/providers/commands.provider.ts
@@ -13,7 +13,7 @@ import { PartialDeep } from "type-fest";
  * those commands.
  *
  * The consumers of the commands should not need
- * to care about where the commands where provided,
+ * to care about where the commands were provided,
  * just that they are available
  */
 

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/providers/models.provider.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/providers/models.provider.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook } from "@testing-library/react";
+import {
+  ModelsContext,
+  ModelsContextInterface,
+  useModels,
+} from "./models.provider";
+import { ITasksModel } from "../models/tasks.model";
+import { IUsersModel } from "../models/users.model";
+
+describe("useModels", () => {
+  it("should work if models are provided", async () => {
+    // arrange
+    const models: ModelsContextInterface = {
+      tasksModel: {} as ITasksModel,
+      usersModel: {} as IUsersModel,
+    };
+
+    const wrapper: React.FC<{
+      children?: React.ReactNode;
+    }> = ({ children }) => (
+      <ModelsContext.Provider value={models}>{children}</ModelsContext.Provider>
+    );
+
+    const { result } = renderHook(() => useModels(), { wrapper });
+
+    expect(result.current).toEqual(models);
+  });
+
+  it("should fail if models are not provided", async () => {
+    // arrange
+    expect(() => renderHook(() => useModels())).toThrowError();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/providers/models.provider.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/providers/models.provider.ts
@@ -10,7 +10,7 @@ import { PartialDeep } from "type-fest";
  * those models.
  *
  * The consumers of the models should not need
- * to care about where the models where provided,
+ * to care about where the models were provided,
  * just that they are available
  */
 

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/views/App/App.view-model.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/views/App/App.view-model.test.tsx
@@ -1,14 +1,15 @@
 import { renderHook } from "@testing-library/react";
-import { AppViewModelDependencies, useAppViewModel } from "./App.view-model";
+import {
+  AppViewModelDependencies,
+  CommandsDependencies,
+  useAppViewModel,
+} from "./App.view-model";
 import { QueryClient } from "@tanstack/query-core";
 import { ISelectedFiltersModel } from "../../models/selected-filters.model";
 import { ITasksModel } from "../../models/tasks.model";
 import { IUsersModel } from "../../models/users.model";
 import { QueryClientProvider } from "@tanstack/react-query";
-import {
-  CommandsContext,
-  CommandsContextInterface,
-} from "../../providers/commands.provider";
+import { CommandsContext } from "../../providers/commands.provider";
 
 describe("useAppViewModel", () => {
   it("should map domain models correctly to view model", async () => {
@@ -25,10 +26,9 @@ describe("useAppViewModel", () => {
       createUsersModel: vi.fn(() => usersModel),
     };
 
-    const commands: CommandsContextInterface = {
+    const commands: CommandsDependencies = {
       addTaskCommand: vi.fn(),
       deleteTaskCommand: vi.fn(),
-      getUserCommand: vi.fn(),
       listTasksCommand: vi.fn(),
       listUsersCommand: vi.fn(),
     };

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/views/App/App.view.stories.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainers/views/App/App.view.stories.tsx
@@ -15,10 +15,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     dependencies: {
-      useAppViewModel: () =>
-        ({
-          models: {},
-        }) as ReturnType<typeof useAppViewModel>,
+      useAppViewModel: () => ({
+        models: {} as ReturnType<typeof useAppViewModel>["models"],
+      }),
       Actions: () => <>Actions</>,
       Filters: () => <>Filters</>,
       TaskList: () => <>TaskList</>,

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/add-task.command.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/add-task.command.test.ts
@@ -1,0 +1,39 @@
+import {
+  AddTaskCommandDependencies,
+  createAddTaskCommand,
+} from "./add-task.command";
+
+/**
+ * This removes unnecessary collect-time for default dependencies
+ */
+vi.mock("./add-task.command.dependencies", () => ({ default: {} }));
+
+describe("AddTaskCommand", () => {
+  it("should work as expected when adding a task", async () => {
+    // arrange
+    const mockDependencies: AddTaskCommandDependencies = {
+      tasksService: {
+        addTask: vi.fn(),
+      },
+    };
+
+    const addTaskCommand = createAddTaskCommand(mockDependencies);
+
+    // add a task
+    await addTaskCommand("Paint house", "user-1");
+
+    // check that the underlying service was called
+    expect(mockDependencies.tasksService?.addTask).toHaveBeenCalledWith(
+      "Paint house",
+      "user-1",
+    );
+
+    // check that error is thrown if text is missing
+    expect(() => addTaskCommand("", "")).toThrowError("Task text is missing");
+
+    // check that error is thrown if category is missing
+    expect(() => addTaskCommand("Do something", "")).toThrowError(
+      "Owner id for task is missing",
+    );
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/add-task.command.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/add-task.command.ts
@@ -1,0 +1,38 @@
+import { ITasksService } from "../services/tasks.service";
+import type { Task } from "../types";
+
+/**
+ * Commands are meant to be single purpose operations that
+ * wrap around one or more services and methods.
+ *
+ * Command handle things like validation, transformation, error mapping, etc
+ * - so that the consumer can use it with as much ease as possible
+ *
+ * Commands should be fully tested to ensure that all validation
+ * and error handling logic is solid, and so that the same things
+ * do not have to be tested through the model or the UI
+ */
+
+export interface IAddTaskCommandInvocation {
+  (text: string, ownerId: string): Promise<Task>;
+}
+
+export type AddTaskCommandDependencies = {
+  tasksService: Pick<ITasksService, "addTask">;
+};
+
+export const createAddTaskCommand = (
+  dependencies: AddTaskCommandDependencies,
+): IAddTaskCommandInvocation => {
+  return (text: string, ownerId: string) => {
+    if (!text) {
+      throw new Error("Task text is missing");
+    }
+
+    if (!ownerId) {
+      throw new Error("Owner id for task is missing");
+    }
+
+    return dependencies.tasksService.addTask(text, ownerId);
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/delete-task.command.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/delete-task.command.test.ts
@@ -1,0 +1,32 @@
+import {
+  createDeleteTaskCommand,
+  DeleteTaskCommandDependencies,
+} from "./delete-task.command";
+
+/**
+ * This removes unnecessary collect-time for default dependencies
+ */
+vi.mock("./delete-task.command.dependencies", () => ({ default: {} }));
+
+describe("DeleteTaskCommand", () => {
+  it("should work as expected when deleting a task", async () => {
+    // arrange
+    const mockDependencies: DeleteTaskCommandDependencies = {
+      tasksService: {
+        deleteTask: vi.fn(async () => {}),
+      },
+    };
+
+    const mockTaskId = "task-1";
+
+    const deleteTaskCommand = createDeleteTaskCommand(mockDependencies);
+
+    // delete the task
+    await deleteTaskCommand(mockTaskId);
+
+    // check that the underlying service was called
+    expect(mockDependencies.tasksService?.deleteTask).toHaveBeenCalledWith(
+      mockTaskId,
+    );
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/delete-task.command.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/delete-task.command.ts
@@ -1,0 +1,29 @@
+import { ITasksService } from "../services/tasks.service";
+
+/**
+ * Commands are meant to be single purpose operations that
+ * wrap around one or more services and methods.
+ *
+ * Command handle things like validation, transformations, error mapping, etc
+ * - so that the consumer can use it with as much ease as possible
+ *
+ * Commands should be fully tested to ensure that all validation
+ * and error handling logic is solid, and so that the same things
+ * do not have to be tested through the model or the UI
+ */
+
+export interface IDeleteTaskCommandInvocation {
+  (taskId: string): Promise<void>;
+}
+
+export type DeleteTaskCommandDependencies = {
+  tasksService: Pick<ITasksService, "deleteTask">;
+};
+
+export const createDeleteTaskCommand = (
+  dependencies: DeleteTaskCommandDependencies,
+): IDeleteTaskCommandInvocation => {
+  return (taskId: string) => {
+    return dependencies.tasksService.deleteTask(taskId);
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/get-user.command.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/get-user.command.test.ts
@@ -1,0 +1,44 @@
+import type { User } from "../types";
+import {
+  createGetUserCommand,
+  GetUserCommandDependencies,
+} from "./get-user.command";
+
+/**
+ * This removes unnecessary collect-time for default dependencies
+ */
+vi.mock("./get-user.command.dependencies", () => ({ default: {} }));
+
+describe("GetUserCommand", () => {
+  it("should work as expected when getting a user by id", async () => {
+    // arrange
+    const mockUser: User = {
+      id: "user-1",
+      name: "John Doe",
+      profileImageUrl: "./src/image.png",
+    };
+
+    const mockDependencies: GetUserCommandDependencies = {
+      usersService: {
+        getUserById: vi.fn(async () => ({
+          id: "user-1",
+          name: "John Doe",
+          profileImageUrl: "./src/image.png",
+        })),
+      },
+    };
+
+    const getUserCommand = createGetUserCommand(mockDependencies);
+
+    // get the user by id
+    const user = await getUserCommand(mockUser.id);
+
+    // check that the users were given as a result
+    expect(user).toEqual(mockUser);
+
+    // check that the underlying service was called
+    expect(mockDependencies.usersService?.getUserById).toHaveBeenCalledWith(
+      mockUser.id,
+    );
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/get-user.command.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/get-user.command.ts
@@ -1,0 +1,30 @@
+import { IUsersService } from "../services/users.service";
+import type { User } from "../types";
+
+/**
+ * Commands are meant to be single purpose operations that
+ * wrap around one or more services and methods.
+ *
+ * Command handle things like validation, transformations, error mapping, etc
+ * - so that the consumer can use it with as much ease as possible
+ *
+ * Commands should be fully tested to ensure that all validation
+ * and error handling logic is solid, and so that the same things
+ * do not have to be tested through the model or the UI
+ */
+
+export interface IGetUserCommandInvocation {
+  (userId: string): Promise<User | undefined>;
+}
+
+export type GetUserCommandDependencies = {
+  usersService: Pick<IUsersService, "getUserById">;
+};
+
+export const createGetUserCommand = (
+  dependencies: GetUserCommandDependencies,
+): IGetUserCommandInvocation => {
+  return (userId: string) => {
+    return dependencies.usersService.getUserById(userId);
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/list-tasks.command.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/list-tasks.command.test.ts
@@ -1,0 +1,31 @@
+import {
+  createListTasksCommand,
+  ListTasksCommandDependencies,
+} from "./list-tasks.command";
+
+/**
+ * This removes unnecessary collect-time for default dependencies
+ */
+vi.mock("./list-tasks.command.dependencies", () => ({ default: {} }));
+
+describe("ListTasksCommand", () => {
+  it("should work as expected when listing tasks", async () => {
+    // arrange
+    const mockDependencies: ListTasksCommandDependencies = {
+      tasksService: {
+        listTasks: vi.fn(async () => []),
+      },
+    };
+
+    const listTasksCommand = createListTasksCommand(mockDependencies);
+
+    // fetch the tasks
+    const tasks = await listTasksCommand();
+
+    // check that the tasks were given as a result
+    expect(tasks).toEqual([]);
+
+    // check that the underlying service was called
+    expect(mockDependencies.tasksService?.listTasks).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/list-tasks.command.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/list-tasks.command.ts
@@ -1,0 +1,31 @@
+import { ITasksService } from "../services/tasks.service";
+import type { Task } from "../types";
+
+/**
+ * Commands are meant to be single purpose operations that
+ * wrap around one or more services and methods.
+ *
+ * Command handle things like validation, transformations, error mapping, etc
+ * - so that the consumer can use it with as much ease as possible
+ *
+ * Commands should be fully tested to ensure that all validation
+ * and error handling logic is solid, and so that the same things
+ * do not have to be tested through the model or the UI
+ */
+
+export interface IListTasksCommandInvocation {
+  (): Promise<Task[]>;
+}
+
+export type ListTasksCommandDependencies = {
+  tasksService: Pick<ITasksService, "listTasks">;
+};
+
+// Command factory
+export const createListTasksCommand = (
+  dependencies: ListTasksCommandDependencies,
+): IListTasksCommandInvocation => {
+  return () => {
+    return dependencies.tasksService.listTasks();
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/list-users.command.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/list-users.command.test.ts
@@ -1,0 +1,31 @@
+import {
+  createListUsersCommand,
+  ListUsersCommandDependencies,
+} from "./list-users.command";
+
+/**
+ * This removes unnecessary collect-time for default dependencies
+ */
+vi.mock("./list-users.command.dependencies", () => ({ default: {} }));
+
+describe("ListUsersCommand", () => {
+  it("should work as expected when listing users", async () => {
+    // arrange
+    const mockDependencies: ListUsersCommandDependencies = {
+      usersService: {
+        listUsers: vi.fn(async () => []),
+      },
+    };
+
+    const listUsersCommand = createListUsersCommand(mockDependencies);
+
+    // fetch the users
+    const users = await listUsersCommand();
+
+    // check that the users were given as a result
+    expect(users).toEqual([]);
+
+    // check that the underlying service was called
+    expect(mockDependencies.usersService?.listUsers).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/list-users.command.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/commands/list-users.command.ts
@@ -1,0 +1,31 @@
+import { IUsersService } from "../services/users.service";
+import type { User } from "../types";
+
+/**
+ * Commands are meant to be single purpose operations that
+ * wrap around one or more services and methods.
+ *
+ * Command handle things like validation, transformations, error mapping, etc
+ * - so that the consumer can use it with as much ease as possible
+ *
+ * Commands should be fully tested to ensure that all validation
+ * and error handling logic is solid, and so that the same things
+ * do not have to be tested through the model or the UI
+ */
+
+export interface IListUsersCommandInvocation {
+  (): Promise<User[]>;
+}
+
+export type ListUsersCommandDependencies = {
+  usersService: Pick<IUsersService, "listUsers">;
+};
+
+// Command factory
+export const createListUsersCommand = (
+  dependencies: ListUsersCommandDependencies,
+): IListUsersCommandInvocation => {
+  return () => {
+    return dependencies.usersService.listUsers();
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view-model.dependencies.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view-model.dependencies.ts
@@ -1,0 +1,38 @@
+import { createAddTaskCommand } from "../../commands/add-task.command";
+import { createDeleteTaskCommand } from "../../commands/delete-task.command";
+import { createGetUserCommand } from "../../commands/get-user.command";
+import { createListTasksCommand } from "../../commands/list-tasks.command";
+import { createListUsersCommand } from "../../commands/list-users.command";
+import { createQueryClient } from "../../utils/create-query-client";
+import { createTasksService } from "../../services/tasks.service";
+import { createUsersService } from "../../services/users.service";
+
+/**
+ * This file contains the interface of the
+ * dependencies for the unit, in addition
+ * to the defaults for those dependencies
+ */
+
+export type RootViewModelDependencies = {
+  createQueryClient: typeof createQueryClient;
+  createTasksService: typeof createTasksService;
+  createUsersService: typeof createUsersService;
+  createAddTaskCommand: typeof createAddTaskCommand;
+  createDeleteTaskCommand: typeof createDeleteTaskCommand;
+  createGetUserCommand: typeof createGetUserCommand;
+  createListTasksCommand: typeof createListTasksCommand;
+  createListUsersCommand: typeof createListUsersCommand;
+};
+
+const defaultDependencies: RootViewModelDependencies = {
+  createQueryClient,
+  createTasksService,
+  createUsersService,
+  createAddTaskCommand,
+  createDeleteTaskCommand,
+  createGetUserCommand,
+  createListTasksCommand,
+  createListUsersCommand,
+};
+
+export default defaultDependencies;

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view-model.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view-model.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from "@testing-library/react";
+import { useRootViewModel } from "./Root.view-model";
+import { QueryClient } from "@tanstack/query-core";
+import { ITasksService } from "../../services/tasks.service";
+import { IUsersService } from "../../services/users.service";
+import type { RootViewModelDependencies } from "./Root.view-model.dependencies";
+
+/**
+ * Remove the default dependencies from the test
+ * so that we avoid the unnecessary collect-time
+ */
+vi.mock("./Root.view-model.dependencies", () => ({ default: {} }));
+
+describe("useRootViewModel", () => {
+  it("should map domain models correctly to view model", async () => {
+    // arrange
+    const queryClient = new QueryClient();
+    const tasksService: ITasksService = {
+      listTasks: vi.fn(),
+      addTask: vi.fn(),
+      deleteTask: vi.fn(),
+    };
+    const usersService: IUsersService = {
+      getUserById: vi.fn(),
+      listUsers: vi.fn(),
+    };
+    const addTaskCommand = vi.fn();
+    const deleteTaskCommand = vi.fn();
+    const getUserCommand = vi.fn();
+    const listTasksCommand = vi.fn();
+    const listUsersCommand = vi.fn();
+
+    const dependencies: RootViewModelDependencies = {
+      createQueryClient: vi.fn(() => queryClient),
+      createTasksService: vi.fn(() => tasksService),
+      createUsersService: vi.fn(() => usersService),
+      createAddTaskCommand: vi.fn(() => addTaskCommand),
+      createDeleteTaskCommand: vi.fn(() => deleteTaskCommand),
+      createGetUserCommand: vi.fn(() => getUserCommand),
+      createListTasksCommand: vi.fn(() => listTasksCommand),
+      createListUsersCommand: vi.fn(() => listUsersCommand),
+    };
+
+    const { result } = renderHook(() => useRootViewModel({ dependencies }));
+
+    expect(result.current).toEqual({
+      commands: {
+        addTaskCommand,
+        deleteTaskCommand,
+        getUserCommand,
+        listTasksCommand,
+        listUsersCommand,
+      },
+      queryClient,
+    });
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view-model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view-model.ts
@@ -1,0 +1,124 @@
+import { useMemo } from "react";
+import defaultDependencies, {
+  RootViewModelDependencies,
+} from "./Root.view-model.dependencies";
+
+/**
+ * The main purpose of this file is to
+ * bridge the business logic and the React view
+ *
+ * Access to business logic is facilitated
+ * by providing custom hooks with appropriate
+ * interfaces - taking care not to expose
+ * implementation details of the business
+ * logic itself or libraries used
+ *
+ * It can also be used for 3rd party library hooks,
+ * so that you avoid coupling your component directly.
+ * Instead you can provide a nice interface and map
+ * the custom hooks into it
+ */
+type Props = {
+  dependencies?: RootViewModelDependencies;
+};
+
+/**
+ * TODO: Here is where the global providers
+ * need to be initialized (potentially in the view model of this)
+ *
+ * - Models
+ * - Commands
+ * - Flags
+ * - Etc..
+ */
+export const useRootViewModel = ({
+  dependencies = defaultDependencies,
+}: Props = {}) => {
+  // Get dependencies
+  const {
+    createQueryClient,
+    createTasksService,
+    createUsersService,
+    createAddTaskCommand,
+    createDeleteTaskCommand,
+    createGetUserCommand,
+    createListTasksCommand,
+    createListUsersCommand,
+  } = dependencies;
+
+  // Get commands from the command provider context
+
+  /**
+   * TODO: Create all the commands first, and then let
+   * them be injected into the models.
+   *
+   * It has to be possible to just replace the command
+   * layer dependencies in the tree and then the models
+   * would work against fake commands.
+   *
+   * Where should the injection of the commands happen?
+   * One layer further up and then this view model
+   * will depend on that context and then inject
+   * them into the models?
+   */
+
+  /**
+   * Create the query client
+   */
+  const queryClient = createQueryClient();
+
+  /**
+   * Create SDK instances
+   */
+  const tasksService = createTasksService();
+  const usersService = createUsersService();
+
+  /**
+   * Create the commands
+   */
+  const addTaskCommand = useMemo(
+    () => createAddTaskCommand({ tasksService }),
+    [createAddTaskCommand, tasksService],
+  );
+  const deleteTaskCommand = useMemo(
+    () => createDeleteTaskCommand({ tasksService }),
+    [createDeleteTaskCommand, tasksService],
+  );
+  const getUserCommand = useMemo(
+    () => createGetUserCommand({ usersService }),
+    [createGetUserCommand, usersService],
+  );
+  const listTasksCommand = useMemo(
+    () => createListTasksCommand({ tasksService }),
+    [createListTasksCommand, tasksService],
+  );
+  const listUsersCommand = useMemo(
+    () => createListUsersCommand({ usersService }),
+    [createListUsersCommand, usersService],
+  );
+
+  /**
+   * Package the commands in an object
+   */
+  const commands = useMemo(
+    () => ({
+      addTaskCommand,
+      deleteTaskCommand,
+      getUserCommand,
+      listTasksCommand,
+      listUsersCommand,
+    }),
+    [
+      addTaskCommand,
+      deleteTaskCommand,
+      getUserCommand,
+      listTasksCommand,
+      listUsersCommand,
+    ],
+  );
+
+  return {
+    queryClient,
+    commands,
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view-model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view-model.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import defaultDependencies, {
   RootViewModelDependencies,
 } from "./Root.view-model.dependencies";
+import { CommandsContextInterface } from "../../providers/commands.provider";
 
 /**
  * The main purpose of this file is to
@@ -100,7 +101,7 @@ export const useRootViewModel = ({
   /**
    * Package the commands in an object
    */
-  const commands = useMemo(
+  const commands: CommandsContextInterface = useMemo(
     () => ({
       addTaskCommand,
       deleteTaskCommand,

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view.dependencies.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view.dependencies.ts
@@ -1,0 +1,20 @@
+import { useRootViewModel } from "./Root.view-model";
+import { App } from "../../views/App/App.view";
+
+/**
+ * This file contains the interface of the
+ * dependencies for the unit, in addition
+ * to the defaults for those dependencies
+ */
+
+export type RootDependencies = {
+  useRootViewModel: typeof useRootViewModel;
+  App: typeof App;
+};
+
+const defaultDependencies: RootDependencies = {
+  useRootViewModel,
+  App,
+};
+
+export default defaultDependencies;

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view.integration.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view.integration.test.tsx
@@ -1,4 +1,3 @@
-import { QueryClient } from "@tanstack/query-core";
 import { render, screen, waitFor } from "@testing-library/react";
 
 import { Task, User } from "../../types";
@@ -10,11 +9,12 @@ import defaultDependencies, {
 } from "./Root.view.dependencies";
 import { ITasksService } from "../../services/tasks.service";
 import { IUsersService } from "../../services/users.service";
+import { createQueryClient } from "../../utils/create-query-client";
 
 describe("Root Integration (view-model layer)", () => {
   it("should reflect changes in filters in all applicable views", async () => {
     // create query client for test
-    const queryClient = new QueryClient();
+    const queryClient = createQueryClient();
 
     // create mock tasks
     const mockTasks: Task[] = [
@@ -121,7 +121,7 @@ describe("Root Integration (view-model layer)", () => {
 describe("Root Integration (view layer)", () => {
   it("should reflect changes in filters in all applicable views", async () => {
     // create query client for test
-    const queryClient = new QueryClient();
+    const queryClient = createQueryClient();
 
     // create mock tasks
     const mockTasks: Task[] = [

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view.integration.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view.integration.test.tsx
@@ -1,44 +1,17 @@
 import { QueryClient } from "@tanstack/query-core";
 import { render, screen, waitFor } from "@testing-library/react";
-import { App } from "./App.view";
+
 import { Task, User } from "../../types";
 import userEvent from "@testing-library/user-event";
-import { createProviderTree } from "../../../../../lib/create-provider-tree";
-import {
-  CommandsContext,
-  CommandsContextInterface,
-  CommandsContextType,
-} from "../../providers/commands.provider";
-import { QueryClientProvider } from "@tanstack/react-query";
-import { useAppViewModel } from "./App.view-model";
-import { Actions } from "../Actions/Actions.view";
-import { Filters } from "../Filters/Filters.view";
-import { TaskList } from "../TaskList/TaskList.view";
-import { useActionsViewModel } from "../Actions/Actions.view-model";
-import { useFiltersViewModel } from "../Filters/Filters.view-model";
-import { useTaskListViewModel } from "../TaskList/TaskList.view-model";
-import { ComponentProps } from "react";
-import { TaskItem } from "../TaskItem/TaskItem.view";
-import {
-  TaskItemViewModelProps,
-  useTaskItemViewModel,
-} from "../TaskItem/TaskItem.view-model";
-import {
-  createUserModel,
-  UserModelDependencies,
-} from "../../models/user.model";
-import { SelectedFiltersModel } from "../../models/selected-filters.model";
-import { UsersModel, UsersModelDependencies } from "../../models/users.model";
-import { TasksModel, TasksModelDependencies } from "../../models/tasks.model";
-import { ActionsDependencies } from "../Actions/Actions.view.dependencies";
-import { AppViewModelDependencies } from "./App.view-model.dependencies";
-import { TaskItemViewModelDependencies } from "../TaskItem/TaskItem.view-model.dependencies";
-import { TaskItemDependencies } from "../TaskItem/TaskItem.view.dependencies";
-import { TaskListDependencies } from "../TaskList/TaskList.view.dependencies";
-import { FiltersDependencies } from "../Filters/Filters.view.dependencies";
-import { AppDependencies } from "./App.view.dependencies";
+import { CommandsContextInterface } from "../../providers/commands.provider";
+import { Root } from "./Root.view";
+import defaultDependencies, {
+  RootDependencies,
+} from "./Root.view.dependencies";
+import { ITasksService } from "../../services/tasks.service";
+import { IUsersService } from "../../services/users.service";
 
-describe("App Integration (only command layer mocked)", () => {
+describe("Root Integration (view-model layer)", () => {
   it("should reflect changes in filters in all applicable views", async () => {
     // create query client for test
     const queryClient = new QueryClient();
@@ -59,12 +32,12 @@ describe("App Integration (only command layer mocked)", () => {
 
     // create mock commands
     const commands: CommandsContextInterface = {
-      listTasksCommand: async () => mockTasks,
       addTaskCommand: async () => ({
         id: "1",
         text: "task",
         ownerId: "user-1",
       }),
+      listTasksCommand: async () => mockTasks,
       deleteTaskCommand: async () => {},
       getUserCommand: async (userId) => {
         return mockUsers.find((user) => user.id === userId);
@@ -72,23 +45,29 @@ describe("App Integration (only command layer mocked)", () => {
       listUsersCommand: async () => mockUsers,
     };
 
-    /**
-     * Create provider tree
-     */
-    const Providers = createProviderTree([
-      <QueryClientProvider client={queryClient} />,
-      <CommandsContext.Provider value={commands} />,
-    ]);
+    // create root dependencies
+    const rootDependencies: RootDependencies = {
+      App: defaultDependencies.App,
+      useRootViewModel: () =>
+        defaultDependencies.useRootViewModel({
+          dependencies: {
+            createAddTaskCommand: () => commands.addTaskCommand,
+            createDeleteTaskCommand: () => commands.deleteTaskCommand,
+            createGetUserCommand: () => commands.getUserCommand,
+            createListTasksCommand: () => commands.listTasksCommand,
+            createListUsersCommand: () => commands.listUsersCommand,
+            createQueryClient: () => queryClient,
+            createTasksService: () => ({}) as ITasksService,
+            createUsersService: () => ({}) as IUsersService,
+          },
+        }),
+    };
 
     /**
      * Render a version that injects all the dependencies
      * we created further up so that we can test our integration
      */
-    render(
-      <Providers>
-        <App />
-      </Providers>,
-    );
+    render(<Root dependencies={rootDependencies} />);
 
     // wait for loading to finish
     await waitFor(() =>
@@ -139,7 +118,7 @@ describe("App Integration (only command layer mocked)", () => {
   });
 });
 
-describe("App Integration (all dependencies explicit)", () => {
+describe("Root Integration (view layer)", () => {
   it("should reflect changes in filters in all applicable views", async () => {
     // create query client for test
     const queryClient = new QueryClient();
@@ -158,102 +137,35 @@ describe("App Integration (all dependencies explicit)", () => {
       { id: "user-2", name: "User 2", profileImageUrl: "./src/user-2" },
     ];
 
-    // Create tasks model dependencies
-    const tasksModelDependencies: TasksModelDependencies = {
-      listTasksCommand: async () => mockTasks,
+    // create mock commands
+    const commands: CommandsContextInterface = {
       addTaskCommand: async () => ({
         id: "1",
         text: "task",
         ownerId: "user-1",
       }),
+      listTasksCommand: async () => mockTasks,
       deleteTaskCommand: async () => {},
-    };
-
-    // Create tasks model
-    const tasksModel = new TasksModel(queryClient, tasksModelDependencies);
-
-    // Create users model dependencies
-    const usersModelDependencies: UsersModelDependencies = {
-      listUsersCommand: async () => mockUsers,
-    };
-
-    // Create users model
-    const usersModel = new UsersModel(queryClient, usersModelDependencies);
-
-    // Create selected filters model
-    const selectedFiltersModel = new SelectedFiltersModel();
-
-    // Create dependencies for UserModel
-    const userModelDependencies: UserModelDependencies = {
       getUserCommand: async (userId) => {
         return mockUsers.find((user) => user.id === userId);
       },
+      listUsersCommand: async () => mockUsers,
     };
 
-    // Create dependencies for TaskItemViewModel
-    const taskItemViewModelDependencies: TaskItemViewModelDependencies = {
-      createUserModel: (userId) => {
-        return createUserModel(userId, queryClient, userModelDependencies);
-      },
+    // create root dependencies
+    const rootDependencies: RootDependencies = {
+      App: defaultDependencies.App,
+      useRootViewModel: () => ({
+        commands,
+        queryClient,
+      }),
     };
-
-    // Create dependencies for TaskItem
-    const taskItemDependencies: TaskItemDependencies = {
-      useTaskItemViewModel: (props: TaskItemViewModelProps) =>
-        useTaskItemViewModel({
-          ...props,
-          dependencies: taskItemViewModelDependencies,
-        }),
-    };
-
-    // Create dependencies for TaskList
-    const taskListDependencies: TaskListDependencies = {
-      TaskItem: (props: ComponentProps<typeof TaskItem>) => (
-        <TaskItem {...props} dependencies={taskItemDependencies} />
-      ),
-      useTaskListViewModel,
-    };
-
-    // Create dependencies for Filters
-    const filtersDependencies: FiltersDependencies = {
-      useFiltersViewModel,
-    };
-
-    // Create dependencies for Actions
-    const actionsDependencies: ActionsDependencies = {
-      useActionsViewModel,
-    };
-
-    // Create app view model dependencies
-    const appViewModelDependencies: AppViewModelDependencies = {
-      createSelectedFiltersModel: () => selectedFiltersModel,
-      createTasksModel: () => tasksModel,
-      createUsersModel: () => usersModel,
-    };
-
-    // Create dependencies for Tasks
-    const appDependencies: AppDependencies = {
-      useAppViewModel: () =>
-        useAppViewModel({ dependencies: appViewModelDependencies }),
-      Actions: () => <Actions dependencies={actionsDependencies} />,
-      Filters: () => <Filters dependencies={filtersDependencies} />,
-      TaskList: () => <TaskList dependencies={taskListDependencies} />,
-    };
-
-    // Create fake commands to inject
-    const commands: CommandsContextType = {};
 
     /**
      * Render a version that injects all the dependencies
      * we created further up so that we can test our integration
      */
-    render(
-      <QueryClientProvider client={queryClient}>
-        <CommandsContext.Provider value={commands}>
-          <App dependencies={appDependencies} />
-        </CommandsContext.Provider>
-      </QueryClientProvider>,
-    );
+    render(<Root dependencies={rootDependencies} />);
 
     // wait for loading to finish
     await waitFor(() =>

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { Root } from "./Root.view";
+import { useRootViewModel } from "./Root.view-model";
+import { QueryClient } from "@tanstack/query-core";
+import { RootDependencies } from "./Root.view.dependencies";
+
+/**
+ * Remove the default dependencies from the test
+ * so that we avoid the unnecessary collect-time
+ */
+vi.mock("./Root.view.dependencies", () => ({ default: {} }));
+
+describe("Root", () => {
+  it("Renders correctly", () => {
+    // arrange
+    const dependencies: RootDependencies = {
+      useRootViewModel: () => ({
+        queryClient: new QueryClient(),
+        commands: {} as ReturnType<typeof useRootViewModel>["commands"],
+        services: {} as ReturnType<typeof useRootViewModel>["services"],
+      }),
+      App: () => <div data-testid="App" />,
+    };
+
+    render(<Root dependencies={dependencies} />);
+
+    // assert
+    expect(screen.getByTestId("App")).toBeInTheDocument();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/containers/Root/Root.view.tsx
@@ -1,0 +1,37 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { CommandsContext } from "../../providers/commands.provider";
+import defaultDependencies, {
+  RootDependencies,
+} from "./Root.view.dependencies";
+
+/**
+ * Here's where we wrap all the top level providers
+ * that should be available to the entire app tree.
+ *
+ * Things like:
+ * - Query client
+ * - Authentication
+ * - Services
+ * - Flags
+ * - Metrics
+ * - Internationalization
+ */
+
+type Props = {
+  dependencies?: RootDependencies;
+};
+
+export function Root({ dependencies = defaultDependencies }: Props) {
+  // Get dependencies
+  const { useRootViewModel, App } = dependencies;
+
+  const { queryClient, commands } = useRootViewModel();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <CommandsContext.Provider value={commands}>
+        <App />
+      </CommandsContext.Provider>
+    </QueryClientProvider>
+  );
+}

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/index.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/index.tsx
@@ -1,0 +1,8 @@
+import { Root } from "./containers/Root/Root.view";
+
+/**
+ * Entry point to the feature
+ */
+export function TasksFeature() {
+  return <Root />;
+}

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/selected-filters.model.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/selected-filters.model.test.ts
@@ -1,0 +1,17 @@
+import { SelectedFiltersModel } from "./selected-filters.model";
+
+describe("SelectedFiltersModel", () => {
+  it("should reflect current selected owner id and handle updates to it", async () => {
+    // arrange
+    const model = new SelectedFiltersModel();
+
+    // check that the category is empty initially
+    expect(model.selectedOwnerId.value).toEqual("");
+
+    // set the selected category to something else
+    model.setSelectedOwnerId("user-1");
+
+    // check that the category change is reflected
+    expect(model.selectedOwnerId.value).toEqual("user-1");
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/selected-filters.model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/selected-filters.model.ts
@@ -1,0 +1,26 @@
+import { ReadonlySignal, signal } from "@preact/signals-core";
+
+export interface ISelectedFiltersModel {
+  selectedOwnerId: ReadonlySignal<string>;
+  setSelectedOwnerId(newSelectedOwner: string): void;
+}
+
+export class SelectedFiltersModel implements ISelectedFiltersModel {
+  // State
+  private _selectedOwnerId = signal<string>("");
+
+  // Getters
+  public get selectedOwnerId(): ReadonlySignal<string> {
+    return this._selectedOwnerId;
+  }
+
+  // Commands
+  public setSelectedOwnerId = (newSelectedOwner: string) => {
+    this._selectedOwnerId.value = newSelectedOwner;
+  };
+}
+
+// Model factory
+export const createSelectedFiltersModel = (
+  ...args: ConstructorParameters<typeof SelectedFiltersModel>
+): ISelectedFiltersModel => new SelectedFiltersModel(...args);

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/tasks.model.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/tasks.model.test.ts
@@ -1,0 +1,280 @@
+import { signal } from "@preact/signals-core";
+import { Task } from "../types";
+import { TasksModelDependencies, TasksModel } from "./tasks.model";
+import { QueryClient } from "@tanstack/query-core";
+
+describe("TasksModel", () => {
+  it("should work as expected when adding a single task", async () => {
+    // arrange
+    let count = 0;
+    const fakeTaskMocks: Task[][] = [
+      [],
+      [{ id: "1", text: "Solve some hard bug", ownerId: "user-1" }],
+    ];
+
+    const mockDependencies: TasksModelDependencies = {
+      addTaskCommand: vi.fn(),
+      deleteTaskCommand: vi.fn(),
+      listTasksCommand: vi.fn(async () => fakeTaskMocks[count++]),
+    };
+
+    const queryClient = new QueryClient();
+    const model = new TasksModel(queryClient, mockDependencies);
+
+    // check that the tasks load initially
+    expect(model.isLoading.value).toEqual(true);
+
+    // wait for the loading to finish
+    await vi.waitFor(() => expect(model.isLoading.value).toEqual(false));
+
+    // check that the tasks were loaded
+    expect(model.tasks.value).toEqual([]);
+    expect(model.tasksCount.value).toEqual(0);
+
+    // add some tasks
+    await model.addTask("Solve some hard bug", "user-1");
+
+    // check that the tasks were added the correct amount of times
+    expect(mockDependencies.addTaskCommand).toHaveBeenCalledOnce();
+
+    // check that the tasks were re-fetched the correct amount of times
+    expect(mockDependencies.listTasksCommand).toHaveBeenCalledTimes(2);
+
+    // check that the list of tasks is correct
+    expect(model.tasks.value).toEqual(fakeTaskMocks[1]);
+    expect(model.tasksCount.value).toEqual(1);
+  });
+
+  it("should work as expected when adding multiple tasks", async () => {
+    // arrange
+    let count = 0;
+    const fakeTaskMocks: Task[][] = [
+      [],
+      [{ id: "1", text: "Fake 1", ownerId: "user-1" }],
+      [
+        { id: "1", text: "Fake 1", ownerId: "user-1" },
+        { id: "2", text: "Fake 2", ownerId: "user-2" },
+      ],
+      [
+        { id: "1", text: "Fake 1", ownerId: "user-1" },
+        { id: "2", text: "Fake 2", ownerId: "user-2" },
+        { id: "3", text: "Fake 3", ownerId: "user-3" },
+      ],
+    ];
+
+    const mockDependencies: TasksModelDependencies = {
+      addTaskCommand: vi.fn(async (task) => task),
+      deleteTaskCommand: vi.fn(),
+      listTasksCommand: vi.fn(async () => fakeTaskMocks[count++]),
+    };
+
+    const queryClient = new QueryClient();
+    const model = new TasksModel(queryClient, mockDependencies);
+
+    // check that the tasks load initially
+    expect(model.isLoading.value).toEqual(true);
+
+    // wait for the loading to finish
+    await vi.waitFor(() => expect(model.isLoading.value).toEqual(false));
+
+    // check that the tasks were loaded
+    expect(model.tasks.value).toEqual([]);
+
+    // add some tasks
+    await model.addTask("Paint house", "user-1");
+    await model.addTask("Buy milk", "user-1");
+    await model.addTask("Wash car", "user-1");
+
+    // check that the tasks were added the correct amount of times
+    expect(mockDependencies.addTaskCommand).toHaveBeenCalledTimes(3);
+
+    // check that the tasks were re-fetched the correct amount of times
+    expect(mockDependencies.listTasksCommand).toHaveBeenCalledTimes(4);
+
+    // check that the list of tasks is correct
+    expect(model.tasks.value).toEqual(fakeTaskMocks[3]);
+    expect(model.tasksCount.value).toEqual(3);
+  });
+
+  it("should work as expected when deleting a task", async () => {
+    // arrange
+    let count = 0;
+    const fakeTaskMocks: Task[][] = [
+      [{ id: "1", text: "Fake 1", ownerId: "user-1" }],
+      [],
+    ];
+
+    const mockDependencies: TasksModelDependencies = {
+      addTaskCommand: vi.fn(async (task) => task),
+      deleteTaskCommand: vi.fn(),
+      listTasksCommand: vi.fn(async () => fakeTaskMocks[count++]),
+    };
+
+    const queryClient = new QueryClient();
+    const model = new TasksModel(queryClient, mockDependencies);
+
+    // check that the tasks load initially
+    expect(model.isLoading.value).toEqual(true);
+
+    // wait for the loading to finish
+    await vi.waitFor(() => expect(model.isLoading.value).toEqual(false));
+
+    // check that the tasks were loaded
+    expect(model.tasks.value).toEqual(fakeTaskMocks[0]);
+    expect(model.tasksCount.value).toEqual(1);
+
+    // add some tasks
+    await model.deleteTask("1");
+
+    // check that the tasks were added the correct amount of times
+    expect(mockDependencies.deleteTaskCommand).toHaveBeenCalledTimes(1);
+
+    // check that the tasks were re-fetched the correct amount of times
+    expect(mockDependencies.listTasksCommand).toHaveBeenCalledTimes(2);
+
+    // check that the list of tasks is correct
+    expect(model.tasks.value).toEqual(fakeTaskMocks[1]);
+    expect(model.tasksCount.value).toEqual(0);
+  });
+
+  it("should not perform deletion if no task id is provided", async () => {
+    // arrange
+    let count = 0;
+    const fakeTaskMocks: Task[][] = [
+      [{ id: "1", text: "Fake 1", ownerId: "user-1" }],
+      [],
+    ];
+
+    const mockDependencies: TasksModelDependencies = {
+      addTaskCommand: vi.fn(async (task) => task),
+      deleteTaskCommand: vi.fn(),
+      listTasksCommand: vi.fn(async () => fakeTaskMocks[count++]),
+    };
+
+    const queryClient = new QueryClient();
+    const model = new TasksModel(queryClient, mockDependencies);
+
+    // check that the tasks load initially
+    expect(model.isLoading.value).toEqual(true);
+
+    // wait for the loading to finish
+    await vi.waitFor(() => expect(model.isLoading.value).toEqual(false));
+
+    // check that the tasks were loaded
+    expect(model.tasks.value).toEqual(fakeTaskMocks[0]);
+    expect(model.tasksCount.value).toEqual(1);
+
+    // add some tasks
+    await model.deleteTask("");
+
+    // check that the tasks were added the correct amount of times
+    expect(mockDependencies.deleteTaskCommand).toHaveBeenCalledTimes(0);
+
+    // check that the tasks were re-fetched the correct amount of times
+    expect(mockDependencies.listTasksCommand).toHaveBeenCalledTimes(1);
+
+    // check that the list of tasks is correct
+    expect(model.tasks.value).toEqual(fakeTaskMocks[0]);
+    expect(model.tasksCount.value).toEqual(1);
+  });
+
+  it("should fail validation when adding empty task", async () => {
+    // arrange
+    let count = 0;
+    const fakeTaskMocks: Task[][] = [
+      [],
+      [{ id: "1", text: "Fake 1", ownerId: "user-1" }],
+    ];
+
+    // arrange
+    const mockDependencies: TasksModelDependencies = {
+      addTaskCommand: vi.fn(),
+      deleteTaskCommand: vi.fn(),
+      listTasksCommand: vi.fn(async () => fakeTaskMocks[count++]),
+    };
+
+    const queryClient = new QueryClient();
+    const model = new TasksModel(queryClient, mockDependencies);
+
+    // check that the tasks load initially
+    expect(model.isLoading.value).toEqual(true);
+
+    // wait for the loading to finish
+    await vi.waitFor(() => expect(model.isLoading.value).toEqual(false));
+
+    // check that the tasks were loaded
+    expect(model.tasks.value).toEqual([]);
+
+    // add a task without a category
+    await model.addTask("Thing", "");
+
+    // add a task without text
+    await model.addTask("", "user-1");
+
+    // check that it never added a task
+    expect(mockDependencies.addTaskCommand).not.toHaveBeenCalled();
+
+    // check that it did not refetch the tasks
+    expect(mockDependencies.listTasksCommand).toHaveBeenCalledOnce();
+
+    // check that the list of tasks is still the same as before
+    expect(model.tasks.value).toEqual(fakeTaskMocks[0]);
+  });
+
+  it("should provide tasks and counts filtered by category correctly", async () => {
+    // arrange
+    const fakeTasks: Task[] = [
+      { id: "1", text: "Task 1", ownerId: "user-1" },
+      { id: "2", text: "Task 2", ownerId: "user-1" },
+      { id: "3", text: "Task 3", ownerId: "user-2" },
+      { id: "4", text: "Task 4", ownerId: "user-2" },
+    ];
+
+    const mockDependencies: TasksModelDependencies = {
+      addTaskCommand: vi.fn(),
+      deleteTaskCommand: vi.fn(),
+      listTasksCommand: vi.fn(async () => fakeTasks),
+    };
+
+    const queryClient = new QueryClient();
+    const model = new TasksModel(queryClient, mockDependencies);
+    const selectedOwnerId = signal("user-1");
+
+    // check that the tasks load initially
+    expect(model.isLoading.value).toEqual(true);
+
+    // wait for the loading to finish
+    await vi.waitFor(() => expect(model.isLoading.value).toEqual(false));
+
+    // check that the tasks were loaded
+    expect(model.tasks.value).toEqual(fakeTasks);
+
+    // create a reference to tasks filtered by category
+    const tasksBySelectedOwnerId = model.getTasksByOwnerId(selectedOwnerId);
+
+    // create a reference to tasks count filtered by category
+    const tasksCountBySelectedOwnerId =
+      model.getTasksCountByOwnerId(selectedOwnerId);
+
+    // check that correct filtered tasks are provided
+    expect(tasksBySelectedOwnerId.value).toEqual([
+      { id: "1", text: "Task 1", ownerId: "user-1" },
+      { id: "2", text: "Task 2", ownerId: "user-1" },
+    ]);
+
+    // check that correct filtered tasks count is provided
+    expect(tasksCountBySelectedOwnerId.value).toEqual(2);
+
+    // change the selected category
+    selectedOwnerId.value = "user-2";
+
+    // check that correct filtered tasks are provided
+    expect(tasksBySelectedOwnerId.value).toEqual([
+      { id: "3", text: "Task 3", ownerId: "user-2" },
+      { id: "4", text: "Task 4", ownerId: "user-2" },
+    ]);
+
+    // check that correct filtered tasks count is provided
+    expect(tasksCountBySelectedOwnerId.value).toEqual(2);
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/tasks.model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/tasks.model.ts
@@ -1,0 +1,176 @@
+import { computed, ReadonlySignal } from "@preact/signals-core";
+
+import {
+  mutation,
+  query,
+  SignalMutation,
+  SignalQuery,
+} from "../../../../lib/query";
+import { QueryClient } from "@tanstack/query-core";
+import { Task } from "../types";
+import { IListTasksCommandInvocation } from "../commands/list-tasks.command";
+import { IAddTaskCommandInvocation } from "../commands/add-task.command";
+import { IDeleteTaskCommandInvocation } from "../commands/delete-task.command";
+
+export interface ITasksModel {
+  tasks: ReadonlySignal<Task[] | undefined>;
+  tasksCount: ReadonlySignal<number>;
+  isLoading: ReadonlySignal<boolean>;
+  isFetching: ReadonlySignal<boolean>;
+  isSaving: ReadonlySignal<boolean>;
+
+  getTasksByOwnerId(
+    selectedOwnerId: ReadonlySignal<string>,
+  ): ReadonlySignal<Task[] | undefined>;
+
+  getTasksCountByOwnerId(
+    selectedOwnerId: ReadonlySignal<string>,
+  ): ReadonlySignal<number>;
+
+  addTask(text: string, ownerId: string): Promise<void>;
+  deleteTask(taskId: string): Promise<void>;
+}
+
+// Types and interfaces
+export type TasksModelDependencies = {
+  listTasksCommand: IListTasksCommandInvocation;
+  addTaskCommand: IAddTaskCommandInvocation;
+  deleteTaskCommand: IDeleteTaskCommandInvocation;
+};
+
+export class TasksModel implements ITasksModel {
+  // Dependencies
+  private _dependencies: TasksModelDependencies;
+
+  // Query client
+  private _queryClient: QueryClient;
+
+  // Queries
+  private _tasksQuery: SignalQuery<Task[]>;
+
+  // Mutations
+  private _addTaskMutation: SignalMutation<
+    {
+      text: string;
+      ownerId: string;
+    },
+    Task
+  >;
+
+  // Mutations
+  private _deleteTaskMutation: SignalMutation<
+    {
+      taskId: string;
+    },
+    void
+  >;
+
+  // Constructor
+  constructor(queryClient: QueryClient, dependencies: TasksModelDependencies) {
+    this._queryClient = queryClient;
+    this._dependencies = dependencies;
+
+    // Queries
+    this._tasksQuery = query<Task[]>(
+      () => ({
+        queryKey: ["tasks"],
+        queryFn: () => this._dependencies.listTasksCommand(),
+      }),
+      () => this._queryClient,
+    );
+
+    // Mutations
+    this._addTaskMutation = mutation(
+      () => ({
+        mutationFn: ({ text, ownerId }: { text: string; ownerId: string }) =>
+          this._dependencies.addTaskCommand(text, ownerId),
+        onSuccess: () => {
+          this._queryClient.invalidateQueries({ queryKey: ["tasks"] });
+        },
+      }),
+      () => this._queryClient,
+    );
+
+    this._deleteTaskMutation = mutation(
+      () => ({
+        mutationFn: ({ taskId }: { taskId: string }) =>
+          this._dependencies.deleteTaskCommand(taskId),
+        onSuccess: () => {
+          this._queryClient.invalidateQueries({ queryKey: ["tasks"] });
+        },
+      }),
+      () => this._queryClient,
+    );
+  }
+
+  // Getters
+  public getTasksByOwnerId(
+    selectedOwnerId: ReadonlySignal<string>,
+  ): ReadonlySignal<Task[] | undefined> {
+    return computed(() => {
+      const selectedOwnerIdValue = selectedOwnerId.value;
+      return this._tasksQuery.value.data?.filter(
+        (task) =>
+          !selectedOwnerIdValue || task.ownerId === selectedOwnerIdValue,
+      );
+    });
+  }
+
+  public get tasks(): ReadonlySignal<Task[] | undefined> {
+    return computed(() => this._tasksQuery.value.data);
+  }
+
+  public getTasksCountByOwnerId(
+    selectedOwnerId: ReadonlySignal<string>,
+  ): ReadonlySignal<number> {
+    return computed(() => {
+      const selectedOwnerIdValue = selectedOwnerId.value;
+      return (
+        this._tasksQuery.value.data?.filter(
+          (task) =>
+            !selectedOwnerIdValue || task.ownerId === selectedOwnerIdValue,
+        ).length || 0
+      );
+    });
+  }
+
+  public get tasksCount(): ReadonlySignal<number> {
+    return computed(() => this._tasksQuery.value.data?.length || 0);
+  }
+
+  public get isLoading(): ReadonlySignal<boolean> {
+    return computed(() => this._tasksQuery.value.isLoading);
+  }
+
+  public get isFetching(): ReadonlySignal<boolean> {
+    return computed(() => this._tasksQuery.value.isFetching);
+  }
+
+  public get isSaving(): ReadonlySignal<boolean> {
+    return computed(() => this._tasksQuery.value.isPending);
+  }
+
+  // Commands
+  public addTask = async (text: string, ownerId: string) => {
+    // Validation
+    if (!text || !ownerId) {
+      return;
+    }
+
+    await this._addTaskMutation.value.mutate({ text, ownerId });
+  };
+
+  public deleteTask = async (taskId: string) => {
+    // Validation
+    if (!taskId) {
+      return;
+    }
+
+    await this._deleteTaskMutation.value.mutate({ taskId });
+  };
+}
+
+// Model factory
+export const createTasksModel = (
+  ...args: ConstructorParameters<typeof TasksModel>
+): ITasksModel => new TasksModel(...args);

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/user.model.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/user.model.test.ts
@@ -1,0 +1,53 @@
+import { User } from "../types";
+import { QueryClient } from "@tanstack/query-core";
+import { UserModel, UserModelDependencies } from "./user.model";
+
+describe("UserModel", () => {
+  it("should initialize correctly", async () => {
+    // arrange
+    const mockUser: User = {
+      id: "user-1",
+      name: "John Doe",
+      profileImageUrl: "./src/profile.png",
+    };
+
+    const mockUserModelDependencies: UserModelDependencies = {
+      getUserCommand: vi.fn(async () => mockUser),
+    };
+
+    const mockQueryClient = new QueryClient();
+    const mockUserId = "user-1";
+
+    const userModel = new UserModel(
+      mockUserId,
+      mockQueryClient,
+      mockUserModelDependencies,
+    );
+
+    expect(userModel.user.value).toBeUndefined();
+    await vi.waitFor(() => expect(userModel.isLoading.value).toBe(true));
+    await vi.waitFor(() => expect(userModel.isLoading.value).toBe(false));
+    expect(userModel.user.value).toEqual(mockUser);
+  });
+
+  it("should expose error if initialization fails", async () => {
+    // arrange
+    const mockUserModelDependencies: UserModelDependencies = {
+      getUserCommand: vi.fn(async () => Promise.reject(new Error("Failed"))),
+    };
+
+    const mockQueryClient = new QueryClient();
+    const mockUserId = "user-1";
+
+    const userModel = new UserModel(
+      mockUserId,
+      mockQueryClient,
+      mockUserModelDependencies,
+    );
+
+    expect(userModel.user.value).toBeUndefined();
+    await vi.waitFor(() => expect(userModel.isLoading.value).toBe(true));
+    await vi.waitFor(() => expect(userModel.error.value).not.toEqual(null));
+    expect(userModel.error.value).toEqual(new Error("Failed"));
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/user.model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/user.model.ts
@@ -1,0 +1,65 @@
+import { computed, ReadonlySignal } from "@preact/signals-core";
+
+import { query, SignalQuery } from "../../../../lib/query";
+import { QueryClient } from "@tanstack/query-core";
+import { User } from "../types";
+import { IGetUserCommandInvocation } from "../commands/get-user.command";
+
+export interface IUserModel {
+  user: ReadonlySignal<User | undefined>;
+  isLoading: ReadonlySignal<boolean>;
+  error: ReadonlySignal<Error | null>;
+}
+
+// Types and interfaces
+export type UserModelDependencies = {
+  getUserCommand: IGetUserCommandInvocation;
+};
+
+export class UserModel implements IUserModel {
+  // Dependencies
+  private _dependencies: UserModelDependencies;
+
+  // Query client
+  private _queryClient: QueryClient;
+
+  // Queries
+  private _userQuery: SignalQuery<User | undefined>;
+
+  // Constructor
+  constructor(
+    userId: string,
+    queryClient: QueryClient,
+    dependencies: UserModelDependencies,
+  ) {
+    this._queryClient = queryClient;
+    this._dependencies = dependencies;
+
+    // Queries
+    this._userQuery = query<User | undefined>(
+      () => ({
+        queryKey: ["user", userId],
+        queryFn: () => this._dependencies.getUserCommand(userId),
+        retry: false,
+      }),
+      () => this._queryClient,
+    );
+  }
+
+  public get user(): ReadonlySignal<User | undefined> {
+    return computed(() => this._userQuery.value.data);
+  }
+
+  public get isLoading(): ReadonlySignal<boolean> {
+    return computed(() => this._userQuery.value.isLoading);
+  }
+
+  public get error(): ReadonlySignal<Error | null> {
+    return computed(() => this._userQuery.value.error);
+  }
+}
+
+// Model factory
+export const createUserModel = (
+  ...args: ConstructorParameters<typeof UserModel>
+): IUserModel => new UserModel(...args);

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/users.model.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/users.model.test.ts
@@ -1,0 +1,56 @@
+import { User } from "../types";
+import { QueryClient } from "@tanstack/query-core";
+import { UsersModel, UsersModelDependencies } from "./users.model";
+
+describe("UsersModel", () => {
+  it("should initialize correctly", async () => {
+    // arrange
+    const mockUsers: User[] = [
+      {
+        id: "user-1",
+        name: "John Doe",
+        profileImageUrl: "./src/profile-1.png",
+      },
+      {
+        id: "user-2",
+        name: "Jane Doe",
+        profileImageUrl: "./src/profile-2.png",
+      },
+    ];
+
+    const mockUsersModelDependencies: UsersModelDependencies = {
+      listUsersCommand: vi.fn(async () => mockUsers),
+    };
+
+    const mockQueryClient = new QueryClient();
+
+    const usersModel = new UsersModel(
+      mockQueryClient,
+      mockUsersModelDependencies,
+    );
+
+    expect(usersModel.users.value).toBeUndefined();
+    await vi.waitFor(() => expect(usersModel.isLoading.value).toBe(true));
+    await vi.waitFor(() => expect(usersModel.isLoading.value).toBe(false));
+    expect(usersModel.users.value).toEqual(mockUsers);
+  });
+
+  it("should expose error if initialization fails", async () => {
+    // arrange
+    const mockUsersModelDependencies: UsersModelDependencies = {
+      listUsersCommand: vi.fn(async () => Promise.reject(new Error("Failed"))),
+    };
+
+    const mockQueryClient = new QueryClient();
+
+    const usersModel = new UsersModel(
+      mockQueryClient,
+      mockUsersModelDependencies,
+    );
+
+    expect(usersModel.users.value).toBeUndefined();
+    await vi.waitFor(() => expect(usersModel.isLoading.value).toBe(true));
+    await vi.waitFor(() => expect(usersModel.error.value).not.toBe(null));
+    expect(usersModel.error.value).toEqual(new Error("Failed"));
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/users.model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/models/users.model.ts
@@ -1,0 +1,61 @@
+import { computed, ReadonlySignal } from "@preact/signals-core";
+
+import { query, SignalQuery } from "../../../../lib/query";
+import { QueryClient } from "@tanstack/query-core";
+import { User } from "../types";
+import { IListUsersCommandInvocation } from "../commands/list-users.command";
+
+export interface IUsersModel {
+  users: ReadonlySignal<User[] | undefined>;
+  isLoading: ReadonlySignal<boolean>;
+  error: ReadonlySignal<Error | null>;
+}
+
+// Types and interfaces
+export type UsersModelDependencies = {
+  listUsersCommand: IListUsersCommandInvocation;
+};
+
+export class UsersModel implements IUsersModel {
+  // Dependencies
+  private _dependencies: UsersModelDependencies;
+
+  // Query client
+  private _queryClient: QueryClient;
+
+  // Queries
+  private _usersQuery: SignalQuery<User[]>;
+
+  // Constructor
+  constructor(queryClient: QueryClient, dependencies: UsersModelDependencies) {
+    this._queryClient = queryClient;
+    this._dependencies = dependencies;
+
+    // Queries
+    this._usersQuery = query<User[]>(
+      () => ({
+        queryKey: ["users"],
+        queryFn: () => this._dependencies.listUsersCommand(),
+        retry: false,
+      }),
+      () => this._queryClient,
+    );
+  }
+
+  public get users(): ReadonlySignal<User[] | undefined> {
+    return computed(() => this._usersQuery.value.data);
+  }
+
+  public get isLoading(): ReadonlySignal<boolean> {
+    return computed(() => this._usersQuery.value.isLoading);
+  }
+
+  public get error(): ReadonlySignal<Error | null> {
+    return computed(() => this._usersQuery.value.error);
+  }
+}
+
+// Model factory
+export const createUsersModel = (
+  ...args: ConstructorParameters<typeof UsersModel>
+): IUsersModel => new UsersModel(...args);

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/providers/commands.provider.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/providers/commands.provider.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook } from "@testing-library/react";
+import {
+  CommandsContext,
+  CommandsContextInterface,
+  useCommands,
+} from "./commands.provider";
+
+describe("useCommands", () => {
+  it("should work if commands are provided", async () => {
+    // arrange
+    const commands: CommandsContextInterface = {
+      addTaskCommand: vi.fn(),
+      deleteTaskCommand: vi.fn(),
+      getUserCommand: vi.fn(),
+      listTasksCommand: vi.fn(),
+      listUsersCommand: vi.fn(),
+    };
+
+    const wrapper: React.FC<{
+      children?: React.ReactNode;
+    }> = ({ children }) => (
+      <CommandsContext.Provider value={commands}>
+        {children}
+      </CommandsContext.Provider>
+    );
+
+    const { result } = renderHook(() => useCommands(), { wrapper });
+
+    expect(result.current).toEqual(commands);
+  });
+
+  it("should fail if commands are not provided", async () => {
+    // arrange
+    expect(() => renderHook(() => useCommands())).toThrowError();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/providers/commands.provider.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/providers/commands.provider.ts
@@ -1,0 +1,42 @@
+import React, { useContext } from "react";
+import { IAddTaskCommandInvocation } from "../commands/add-task.command";
+import { IDeleteTaskCommandInvocation } from "../commands/delete-task.command";
+import { IGetUserCommandInvocation } from "../commands/get-user.command";
+import { IListTasksCommandInvocation } from "../commands/list-tasks.command";
+import { IListUsersCommandInvocation } from "../commands/list-users.command";
+import { PartialDeep } from "type-fest";
+
+/**
+ * The purpose of this context is to be able to
+ * share the commands throughout the application,
+ * and that any layer can be the provider of
+ * those commands.
+ *
+ * The consumers of the commands should not need
+ * to care about where the commands were provided,
+ * just that they are available
+ */
+
+export interface CommandsContextInterface {
+  addTaskCommand: IAddTaskCommandInvocation;
+  deleteTaskCommand: IDeleteTaskCommandInvocation;
+  getUserCommand: IGetUserCommandInvocation;
+  listTasksCommand: IListTasksCommandInvocation;
+  listUsersCommand: IListUsersCommandInvocation;
+}
+
+export type CommandsContextType = PartialDeep<CommandsContextInterface>;
+
+export const CommandsContext = React.createContext<
+  CommandsContextType | undefined
+>(undefined);
+
+export const useCommands = <T extends CommandsContextType>() => {
+  const commands = useContext(CommandsContext);
+
+  if (!commands) {
+    throw new Error("Commands must be provided");
+  }
+
+  return commands as T;
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/providers/models.provider.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/providers/models.provider.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook } from "@testing-library/react";
+import {
+  ModelsContext,
+  ModelsContextInterface,
+  useModels,
+} from "./models.provider";
+import { ITasksModel } from "../models/tasks.model";
+import { IUsersModel } from "../models/users.model";
+
+describe("useModels", () => {
+  it("should work if models are provided", async () => {
+    // arrange
+    const models: ModelsContextInterface = {
+      tasksModel: {} as ITasksModel,
+      usersModel: {} as IUsersModel,
+    };
+
+    const wrapper: React.FC<{
+      children?: React.ReactNode;
+    }> = ({ children }) => (
+      <ModelsContext.Provider value={models}>{children}</ModelsContext.Provider>
+    );
+
+    const { result } = renderHook(() => useModels(), { wrapper });
+
+    expect(result.current).toEqual(models);
+  });
+
+  it("should fail if models are not provided", async () => {
+    // arrange
+    expect(() => renderHook(() => useModels())).toThrowError();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/providers/models.provider.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/providers/models.provider.ts
@@ -1,0 +1,36 @@
+import React, { useContext } from "react";
+import { IUsersModel } from "../models/users.model";
+import { ITasksModel } from "../models/tasks.model";
+import { PartialDeep } from "type-fest";
+
+/**
+ * The purpose of this context is to be able to
+ * share models throughout the application,
+ * and that any layer can be the provider of
+ * those models.
+ *
+ * The consumers of the models should not need
+ * to care about where the models were provided,
+ * just that they are available
+ */
+
+export interface ModelsContextInterface {
+  tasksModel: ITasksModel;
+  usersModel: IUsersModel;
+}
+
+export type ModelsContextType = PartialDeep<ModelsContextInterface>;
+
+export const ModelsContext = React.createContext<ModelsContextType | undefined>(
+  undefined,
+);
+
+export const useModels = <T extends ModelsContextType>() => {
+  const models = useContext(ModelsContext);
+
+  if (!models) {
+    throw new Error("Models must be provided");
+  }
+
+  return models as T;
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/tasks.service.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/tasks.service.test.ts
@@ -1,0 +1,71 @@
+import { Task } from "../types";
+import { TasksService, TasksServiceDependencies } from "./tasks.service";
+
+describe("Tasks Service", () => {
+  it("should reflect the initial value", async () => {
+    // arrange
+    const initialTasks: Task[] = [];
+
+    const tasksServiceDependencies: TasksServiceDependencies = {
+      generateId: vi.fn(() => "abc"),
+      delay: 0,
+    };
+
+    const tasksService = new TasksService(
+      tasksServiceDependencies,
+      initialTasks,
+    );
+
+    // act
+    const tasks = await tasksService.listTasks();
+
+    // assert
+    expect(tasks).toEqual(initialTasks);
+  });
+
+  it("should reflect added tasks", async () => {
+    // arrange
+    const initialTasks: Task[] = [];
+
+    const tasksServiceDependencies: TasksServiceDependencies = {
+      generateId: vi.fn(() => "abc"),
+      delay: 0,
+    };
+
+    const tasksService = new TasksService(
+      tasksServiceDependencies,
+      initialTasks,
+    );
+
+    // act
+    await tasksService.addTask("New task", "user-1");
+    const tasks = await tasksService.listTasks();
+
+    // assert
+    expect(tasks).toEqual([{ id: "abc", text: "New task", ownerId: "user-1" }]);
+  });
+
+  it("should reflect deleted tasks", async () => {
+    // arrange
+    const initialTasks: Task[] = [
+      { id: "abc", text: "New task", ownerId: "user-1" },
+    ];
+
+    const tasksServiceDependencies: TasksServiceDependencies = {
+      generateId: vi.fn(() => "abc"),
+      delay: 0,
+    };
+
+    const tasksService = new TasksService(
+      tasksServiceDependencies,
+      initialTasks,
+    );
+
+    // act
+    await tasksService.deleteTask("abc");
+    const tasks = await tasksService.listTasks();
+
+    // assert
+    expect(tasks).toEqual([]);
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/tasks.service.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/tasks.service.test.ts
@@ -1,5 +1,5 @@
 import { Task } from "../types";
-import { TasksService, TasksServiceDependencies } from "./tasks.service";
+import { createTasksService, TasksServiceDependencies } from "./tasks.service";
 
 describe("Tasks Service", () => {
   it("should reflect the initial value", async () => {
@@ -11,7 +11,7 @@ describe("Tasks Service", () => {
       delay: 0,
     };
 
-    const tasksService = new TasksService(
+    const tasksService = createTasksService(
       tasksServiceDependencies,
       initialTasks,
     );
@@ -32,7 +32,7 @@ describe("Tasks Service", () => {
       delay: 0,
     };
 
-    const tasksService = new TasksService(
+    const tasksService = createTasksService(
       tasksServiceDependencies,
       initialTasks,
     );
@@ -56,7 +56,7 @@ describe("Tasks Service", () => {
       delay: 0,
     };
 
-    const tasksService = new TasksService(
+    const tasksService = createTasksService(
       tasksServiceDependencies,
       initialTasks,
     );

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/tasks.service.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/tasks.service.ts
@@ -1,0 +1,80 @@
+import { generateId, sleep } from "../../../../lib/utils";
+import { Task } from "../types";
+
+/**
+ * Services are typically things like SDKs, APIs or other classes that
+ * expose a bunch of methods to interact with some internal state,
+ * which might reside on the client and/or the server through some network layer
+ *
+ * Services will often interact with an sdk or directly with an API, so that
+ * testing a service will often involve either using a mock for the SDK,
+ * or things like mock-service-worker or nock (mocking the network layer)
+ */
+export interface ITasksService {
+  listTasks(): Promise<Task[]>;
+  addTask(text: string, ownerId: string): Promise<Task>;
+  deleteTask(taskId: string): Promise<void>;
+}
+
+export type TasksServiceDependencies = {
+  generateId: () => string;
+  delay: number;
+};
+
+const defaultDependencies: TasksServiceDependencies = {
+  generateId,
+  delay: 1000,
+};
+
+const defaultTasks: Task[] = [
+  { id: "1", text: "Write self reflection", ownerId: "user-1" },
+  { id: "2", text: "Fix that bug", ownerId: "user-2" },
+];
+
+export class TasksService implements ITasksService {
+  private _tasks: Task[];
+
+  private _dependencies: TasksServiceDependencies;
+
+  constructor(
+    dependencies: TasksServiceDependencies = defaultDependencies,
+    initialTasks: Task[] = defaultTasks,
+  ) {
+    this._dependencies = dependencies;
+    this._tasks = initialTasks;
+  }
+
+  public async listTasks() {
+    await sleep(this._dependencies.delay);
+    return this._tasks.slice();
+  }
+
+  public async addTask(text: string, ownerId: string) {
+    await sleep(this._dependencies.delay);
+
+    const newTask = {
+      id: this._dependencies.generateId(),
+      text,
+      ownerId,
+    };
+
+    this._tasks.splice(0, this._tasks.length, ...this._tasks, newTask);
+
+    return newTask;
+  }
+
+  public async deleteTask(taskId: string) {
+    await sleep(this._dependencies.delay);
+
+    this._tasks.splice(
+      0,
+      this._tasks.length,
+      ...this._tasks.filter((task) => task.id !== taskId),
+    );
+  }
+}
+
+// Service factory
+export const createTasksService = (
+  ...args: ConstructorParameters<typeof TasksService>
+): ITasksService => new TasksService(...args);

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/users.service.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/users.service.test.ts
@@ -1,0 +1,50 @@
+import { User } from "../types";
+import { UsersService, UsersServiceDependencies } from "./users.service";
+
+describe("Users Service", () => {
+  it("should list users correctly", async () => {
+    // arrange
+    const initialUsers: User[] = [];
+
+    const usersServiceDependencies: UsersServiceDependencies = {
+      delay: 0,
+    };
+
+    const usersService = new UsersService(
+      usersServiceDependencies,
+      initialUsers,
+    );
+
+    // act
+    const users = await usersService.listUsers();
+
+    // assert
+    expect(users).toEqual(initialUsers);
+  });
+
+  it("should get user by id correctly", async () => {
+    // arrange
+    const initialUsers: User[] = [
+      { id: "user-1", name: "User 1", profileImageUrl: "/src/img.png" },
+    ];
+
+    const usersServiceDependencies: UsersServiceDependencies = {
+      delay: 0,
+    };
+
+    const usersService = new UsersService(
+      usersServiceDependencies,
+      initialUsers,
+    );
+
+    // act
+    const user = await usersService.getUserById("user-1");
+
+    // assert
+    expect(user).toEqual({
+      id: "user-1",
+      name: "User 1",
+      profileImageUrl: "/src/img.png",
+    });
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/users.service.test.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/users.service.test.ts
@@ -1,5 +1,5 @@
 import { User } from "../types";
-import { UsersService, UsersServiceDependencies } from "./users.service";
+import { createUsersService, UsersServiceDependencies } from "./users.service";
 
 describe("Users Service", () => {
   it("should list users correctly", async () => {
@@ -10,7 +10,7 @@ describe("Users Service", () => {
       delay: 0,
     };
 
-    const usersService = new UsersService(
+    const usersService = createUsersService(
       usersServiceDependencies,
       initialUsers,
     );
@@ -32,7 +32,7 @@ describe("Users Service", () => {
       delay: 0,
     };
 
-    const usersService = new UsersService(
+    const usersService = createUsersService(
       usersServiceDependencies,
       initialUsers,
     );

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/users.service.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/services/users.service.ts
@@ -1,0 +1,58 @@
+import { sleep } from "../../../../lib/utils";
+import { User } from "../types";
+
+/**
+ * Services are typically things like SDKs, APIs or other classes that
+ * expose a bunch of methods to interact with some internal state,
+ * which might reside on the client and/or the server through some network layer
+ *
+ * Services will often interact with an sdk or directly with an API, so that
+ * testing a service will often involve either using a mock for the SDK,
+ * or things like mock-service-worker or nock (mocking the network layer)
+ */
+export interface IUsersService {
+  listUsers(): Promise<User[]>;
+  getUserById(userId: string): Promise<User | undefined>;
+}
+
+export type UsersServiceDependencies = {
+  delay: number;
+};
+
+const defaultDependencies: UsersServiceDependencies = {
+  delay: 1000,
+};
+
+const defaultUsers: User[] = [
+  { id: "user-1", name: "Frank Doe", profileImageUrl: "/img/user-1.jpg" },
+  { id: "user-2", name: "Jane Johnson", profileImageUrl: "/img/user-2.jpg" },
+];
+
+export class UsersService implements IUsersService {
+  private _users: User[];
+
+  private _dependencies: UsersServiceDependencies;
+
+  constructor(
+    dependencies: UsersServiceDependencies = defaultDependencies,
+    initialUsers: User[] = defaultUsers,
+  ) {
+    this._dependencies = dependencies;
+    this._users = initialUsers;
+  }
+
+  public async listUsers() {
+    await sleep(this._dependencies.delay);
+    return this._users.slice();
+  }
+
+  public async getUserById(userId: string) {
+    await sleep(this._dependencies.delay);
+    return this._users.find((user) => user.id === userId);
+  }
+}
+
+// Service factory
+export const createUsersService = (
+  ...args: ConstructorParameters<typeof UsersService>
+): IUsersService => new UsersService(...args);

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/types.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/types.ts
@@ -1,0 +1,11 @@
+export interface Task {
+  id: string;
+  text: string;
+  ownerId: string;
+}
+
+export interface User {
+  id: string;
+  name: string;
+  profileImageUrl: string;
+}

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/utils/create-query-client.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/utils/create-query-client.ts
@@ -1,0 +1,5 @@
+import { QueryClient } from "@tanstack/query-core";
+
+export function createQueryClient() {
+  return new QueryClient();
+}

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view-model.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view-model.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook } from "@testing-library/react";
+import { ModelsDependencies, useActionsViewModel } from "./Actions.view-model";
+import { signal } from "@preact/signals-core";
+import { ModelsContext } from "../../providers/models.provider";
+
+describe("useActionsViewModel", () => {
+  it("should map domain models correctly to view model", async () => {
+    // arrange
+    const addTask = vi.fn();
+
+    const mockModels: ModelsDependencies = {
+      tasksModel: {
+        addTask,
+      },
+      usersModel: {
+        users: signal([]),
+      },
+    };
+
+    const wrapper: React.FC<{
+      children?: React.ReactNode;
+    }> = ({ children }) => (
+      <ModelsContext.Provider value={mockModels}>
+        {children}
+      </ModelsContext.Provider>
+    );
+
+    const { result } = renderHook(() => useActionsViewModel(), { wrapper });
+
+    expect(result.current).toEqual({
+      users: [],
+      addTask,
+    });
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view-model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view-model.ts
@@ -1,0 +1,38 @@
+import { useSignalValue } from "../../../../../lib/use-signal-value";
+import { useModels } from "../../providers/models.provider";
+import { IUsersModel } from "../../models/users.model";
+import { ITasksModel } from "../../models/tasks.model";
+
+/**
+ * The main purpose of this file is to
+ * bridge the business logic and the React view
+ *
+ * Access to business logic is facilitated
+ * by providing custom hooks with appropriate
+ * interfaces - taking care not to expose
+ * implementation details of the business
+ * logic itself or libraries used
+ *
+ * It can also be used for 3rd party library hooks,
+ * so that you avoid coupling your component directly.
+ * Instead you can provide a nice interface and map
+ * the custom hooks into it
+ */
+
+export interface ModelsDependencies {
+  usersModel: Pick<IUsersModel, "users">;
+  tasksModel: Pick<ITasksModel, "addTask">;
+}
+
+export const useActionsViewModel = () => {
+  // Get models from models provider
+  const models = useModels<ModelsDependencies>();
+
+  // Pull out the stuff we want from the shared models
+  const { usersModel, tasksModel } = models;
+
+  return {
+    users: useSignalValue(usersModel.users),
+    addTask: tasksModel.addTask,
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view.dependencies.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view.dependencies.ts
@@ -1,0 +1,17 @@
+import { useActionsViewModel } from "./Actions.view-model";
+
+/**
+ * This file contains the interface of the
+ * dependencies for the unit, in addition
+ * to the defaults for those dependencies
+ */
+
+export type ActionsDependencies = {
+  useActionsViewModel: typeof useActionsViewModel;
+};
+
+const defaultDependencies: ActionsDependencies = {
+  useActionsViewModel,
+};
+
+export default defaultDependencies;

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view.stories.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view.stories.tsx
@@ -1,0 +1,62 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Actions } from "./Actions.view";
+
+const meta = {
+  component: Actions,
+  title: "Actions",
+  tags: ["autodocs"],
+} satisfies Meta<typeof Actions>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const NoUsersAvailable: Story = {
+  args: {
+    dependencies: {
+      useActionsViewModel: () => ({
+        users: [],
+        addTask: async () => {},
+      }),
+    },
+  },
+};
+
+export const SingleUserAvailable: Story = {
+  args: {
+    dependencies: {
+      useActionsViewModel: () => ({
+        users: [
+          {
+            id: "user-1",
+            name: "John Doe",
+            profileImageUrl: "./src/test.png",
+          },
+        ],
+        addTask: async () => {},
+      }),
+    },
+  },
+};
+
+export const MultipleUsersAvailable: Story = {
+  args: {
+    dependencies: {
+      useActionsViewModel: () => ({
+        users: [
+          {
+            id: "user-1",
+            name: "John Doe",
+            profileImageUrl: "./src/test.png",
+          },
+          {
+            id: "user-2",
+            name: "Jane Doe",
+            profileImageUrl: "./src/test.png",
+          },
+        ],
+        addTask: async () => {},
+      }),
+    },
+  },
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Actions } from "./Actions.view";
+import { ActionsDependencies } from "./Actions.view.dependencies";
+
+/**
+ * Remove the default dependencies from the test
+ * so that we avoid the unnecessary collect-time
+ */
+vi.mock("./Actions.view.dependencies", () => ({ default: {} }));
+
+describe("Actions Component", () => {
+  it("Renders correctly", () => {
+    // arrange
+    const mockDependencies: ActionsDependencies = {
+      useActionsViewModel: vi.fn(() => ({
+        users: [],
+        addTask: vi.fn(),
+      })),
+    };
+
+    render(<Actions dependencies={mockDependencies} />);
+
+    // assert
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+  });
+
+  it("Calls the correct handler when adding a task", async () => {
+    // arrange
+    const addTask = vi.fn();
+    const mockDependencies: ActionsDependencies = {
+      useActionsViewModel: vi.fn(() => ({
+        users: [
+          {
+            id: "user-1",
+            name: "John Doe",
+            profileImageUrl: "./src/test.png",
+          },
+        ],
+        addTask,
+      })),
+    };
+
+    // act
+    render(<Actions dependencies={mockDependencies} />);
+
+    // assert
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+
+    // act
+    await userEvent.type(screen.getByLabelText("Add task"), "Paint house");
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "User:" }),
+      "John Doe",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "+" }));
+
+    // assert
+    expect(addTask).toHaveBeenCalledWith("Paint house", "user-1");
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Actions/Actions.view.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useState } from "react";
+import defaultDependencies, {
+  ActionsDependencies,
+} from "./Actions.view.dependencies";
+
+type Props = {
+  dependencies?: ActionsDependencies;
+};
+
+export function Actions({ dependencies = defaultDependencies }: Props) {
+  // Get dependencies
+  const { useActionsViewModel } = dependencies;
+
+  // Use view model
+  const { addTask, users = [] } = useActionsViewModel();
+
+  // Local view state
+  const [selectedUserId, setSelectedUserId] = useState("");
+  const [taskText, setTaskText] = useState("");
+
+  const handleChangeUser = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedUserId(event.target.value);
+    },
+    [],
+  );
+
+  const handleChangeTaskText = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setTaskText(event.target.value);
+    },
+    [],
+  );
+
+  const handleSubmitTask = useCallback(() => {
+    addTask(taskText, selectedUserId);
+    setTaskText("");
+  }, [addTask, selectedUserId, taskText]);
+
+  const userOptions = [
+    <option key={"no-selection"} disabled value={""}>
+      Select a user
+    </option>,
+    ...users.map((user) => (
+      <option key={user.id} value={user.id}>
+        {user.name}
+      </option>
+    )),
+  ];
+
+  return (
+    <div>
+      <h3>Actions</h3>
+      <div>
+        <label>
+          Add task
+          <input type="text" value={taskText} onChange={handleChangeTaskText} />
+        </label>
+        <label>
+          User:
+          <select value={selectedUserId} onChange={handleChangeUser}>
+            {userOptions}
+          </select>
+        </label>
+        <button onClick={handleSubmitTask}>+</button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view-model.dependencies.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view-model.dependencies.ts
@@ -1,0 +1,23 @@
+import { createTasksModel } from "../../models/tasks.model";
+import { createUsersModel } from "../../models/users.model";
+import { createSelectedFiltersModel } from "../../models/selected-filters.model";
+
+/**
+ * This file contains the interface of the
+ * dependencies for the unit, in addition
+ * to the defaults for those dependencies
+ */
+
+export type AppViewModelDependencies = {
+  createTasksModel: typeof createTasksModel;
+  createUsersModel: typeof createUsersModel;
+  createSelectedFiltersModel: typeof createSelectedFiltersModel;
+};
+
+const defaultDependencies: AppViewModelDependencies = {
+  createTasksModel,
+  createUsersModel,
+  createSelectedFiltersModel,
+};
+
+export default defaultDependencies;

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view-model.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view-model.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook } from "@testing-library/react";
+import { CommandsDependencies, useAppViewModel } from "./App.view-model";
+import { QueryClient } from "@tanstack/query-core";
+import { ISelectedFiltersModel } from "../../models/selected-filters.model";
+import { ITasksModel } from "../../models/tasks.model";
+import { IUsersModel } from "../../models/users.model";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { CommandsContext } from "../../providers/commands.provider";
+import { AppViewModelDependencies } from "./App.view-model.dependencies";
+
+/**
+ * Remove the default dependencies from the test
+ * so that we avoid the unnecessary collect-time
+ */
+vi.mock("./App.view-model.dependencies", () => ({ default: {} }));
+
+describe("useAppViewModel", () => {
+  it("should map domain models correctly to view model", async () => {
+    // arrange
+    const queryClient = new QueryClient();
+
+    const selectedFiltersModel = {} as ISelectedFiltersModel;
+    const tasksModel = {} as ITasksModel;
+    const usersModel = {} as IUsersModel;
+
+    const dependencies: AppViewModelDependencies = {
+      createSelectedFiltersModel: vi.fn(() => selectedFiltersModel),
+      createTasksModel: vi.fn(() => tasksModel),
+      createUsersModel: vi.fn(() => usersModel),
+    };
+
+    const commands: CommandsDependencies = {
+      addTaskCommand: vi.fn(),
+      deleteTaskCommand: vi.fn(),
+      listTasksCommand: vi.fn(),
+      listUsersCommand: vi.fn(),
+    };
+
+    const wrapper: React.FC<{
+      children?: React.ReactNode;
+    }> = ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        <CommandsContext.Provider value={commands}>
+          {children}
+        </CommandsContext.Provider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useAppViewModel({ dependencies }), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual({
+      models: {
+        selectedFiltersModel,
+        tasksModel,
+        usersModel,
+      },
+    });
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view-model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view-model.ts
@@ -1,14 +1,13 @@
 import { useMemo } from "react";
-import { createTasksModel } from "../../models/tasks.model";
-import { createUsersModel } from "../../models/users.model";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCommands } from "../../providers/commands.provider";
 import { IAddTaskCommandInvocation } from "../../commands/add-task.command";
 import { IDeleteTaskCommandInvocation } from "../../commands/delete-task.command";
 import { IListTasksCommandInvocation } from "../../commands/list-tasks.command";
 import { IListUsersCommandInvocation } from "../../commands/list-users.command";
-import { createSelectedFiltersModel } from "../../models/selected-filters.model";
-import { AppViewModelDependencies } from "./App.view-model.dependencies";
+import defaultDependencies, {
+  AppViewModelDependencies,
+} from "./App.view-model.dependencies";
 
 /**
  * The main purpose of this file is to
@@ -43,11 +42,7 @@ export interface CommandsDependencies {
  * to the rest of the tree for consumption
  */
 export const useAppViewModel = ({
-  dependencies = {
-    createTasksModel,
-    createUsersModel,
-    createSelectedFiltersModel,
-  },
+  dependencies = defaultDependencies,
 }: Props = {}) => {
   // Get dependencies
   const { createTasksModel, createUsersModel, createSelectedFiltersModel } =

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view-model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view-model.ts
@@ -1,0 +1,130 @@
+import { useMemo } from "react";
+import { createTasksModel } from "../../models/tasks.model";
+import { createUsersModel } from "../../models/users.model";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCommands } from "../../providers/commands.provider";
+import { IAddTaskCommandInvocation } from "../../commands/add-task.command";
+import { IDeleteTaskCommandInvocation } from "../../commands/delete-task.command";
+import { IListTasksCommandInvocation } from "../../commands/list-tasks.command";
+import { IListUsersCommandInvocation } from "../../commands/list-users.command";
+import { createSelectedFiltersModel } from "../../models/selected-filters.model";
+import { AppViewModelDependencies } from "./App.view-model.dependencies";
+
+/**
+ * The main purpose of this file is to
+ * bridge the business logic and the React view
+ *
+ * Access to business logic is facilitated
+ * by providing custom hooks with appropriate
+ * interfaces - taking care not to expose
+ * implementation details of the business
+ * logic itself or libraries used
+ *
+ * It can also be used for 3rd party library hooks,
+ * so that you avoid coupling your component directly.
+ * Instead you can provide a nice interface and map
+ * the custom hooks into it
+ */
+
+type Props = {
+  dependencies?: AppViewModelDependencies;
+};
+
+export interface CommandsDependencies {
+  addTaskCommand: IAddTaskCommandInvocation;
+  deleteTaskCommand: IDeleteTaskCommandInvocation;
+  listTasksCommand: IListTasksCommandInvocation;
+  listUsersCommand: IListUsersCommandInvocation;
+}
+
+/**
+ * This is where the shared/global models
+ * will be initialized and provided
+ * to the rest of the tree for consumption
+ */
+export const useAppViewModel = ({
+  dependencies = {
+    createTasksModel,
+    createUsersModel,
+    createSelectedFiltersModel,
+  },
+}: Props = {}) => {
+  // Get dependencies
+  const { createTasksModel, createUsersModel, createSelectedFiltersModel } =
+    dependencies;
+
+  // Get the query client from the context
+  const queryClient = useQueryClient();
+
+  // Get commands from the command provider context
+  const commands = useCommands<CommandsDependencies>();
+
+  const {
+    addTaskCommand,
+    deleteTaskCommand,
+    listTasksCommand,
+    listUsersCommand,
+  } = commands;
+
+  /**
+   * TODO: Create all the commands first, and then let
+   * them be injected into the models.
+   *
+   * It has to be possible to just replace the command
+   * layer dependencies in the tree and then the models
+   * would work against fake commands.
+   *
+   * Where should the injection of the commands happen?
+   * One layer further up and then this view model
+   * will depend on that context and then inject
+   * them into the models?
+   */
+
+  /**
+   * Create the models
+   */
+  const usersModel = useMemo(
+    () =>
+      createUsersModel(queryClient, {
+        listUsersCommand,
+      }),
+    [createUsersModel, listUsersCommand, queryClient],
+  );
+
+  const tasksModel = useMemo(
+    () =>
+      createTasksModel(queryClient, {
+        addTaskCommand,
+        deleteTaskCommand,
+        listTasksCommand,
+      }),
+    [
+      addTaskCommand,
+      createTasksModel,
+      deleteTaskCommand,
+      listTasksCommand,
+      queryClient,
+    ],
+  );
+
+  const selectedFiltersModel = useMemo(
+    () => createSelectedFiltersModel(),
+    [createSelectedFiltersModel],
+  );
+
+  /**
+   * Package the models in an object
+   */
+  const models = useMemo(
+    () => ({
+      usersModel,
+      tasksModel,
+      selectedFiltersModel,
+    }),
+    [selectedFiltersModel, tasksModel, usersModel],
+  );
+
+  return {
+    models,
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.dependencies.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.dependencies.ts
@@ -1,0 +1,26 @@
+import { Actions } from "../Actions/Actions.view";
+import { Filters } from "../Filters/Filters.view";
+import { TaskList } from "../TaskList/TaskList.view";
+import { useAppViewModel } from "./App.view-model";
+
+/**
+ * This file contains the interface of the
+ * dependencies for the unit, in addition
+ * to the defaults for those dependencies
+ */
+
+export type AppDependencies = {
+  useAppViewModel: typeof useAppViewModel;
+  Actions: typeof Actions;
+  Filters: typeof Filters;
+  TaskList: typeof TaskList;
+};
+
+const defaultDependencies: AppDependencies = {
+  useAppViewModel,
+  Actions,
+  Filters,
+  TaskList,
+};
+
+export default defaultDependencies;

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.integration.stories.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.integration.stories.tsx
@@ -1,0 +1,85 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { App } from "./App.view";
+import { QueryClient } from "@tanstack/query-core";
+import { Task, User } from "../../types";
+import { QueryClientProvider } from "@tanstack/react-query";
+import {
+  CommandsContext,
+  CommandsContextInterface,
+} from "../../providers/commands.provider";
+import { createProviderTree } from "../../../../../lib/create-provider-tree";
+
+const meta = {
+  render: (_, { parameters }) => {
+    // create query client for test
+    const queryClient = new QueryClient();
+
+    // create mock tasks
+    const mockTasks: Task[] = parameters.tasks;
+
+    // create mock users
+    const mockUsers: User[] = parameters.users;
+
+    // create mock commands
+    const commands: CommandsContextInterface = {
+      listTasksCommand: async () => mockTasks,
+      addTaskCommand: async () => ({
+        id: "1",
+        text: "task",
+        ownerId: "user-1",
+      }),
+      deleteTaskCommand: async () => {},
+      getUserCommand: async (userId) => {
+        return mockUsers.find((user) => user.id === userId);
+      },
+      listUsersCommand: async () => mockUsers,
+    };
+
+    /**
+     * Create provider tree
+     */
+    const Providers = createProviderTree([
+      <QueryClientProvider client={queryClient} />,
+      <CommandsContext.Provider value={commands} />,
+    ]);
+
+    /**
+     * Render a version that injects all the dependencies
+     * we created further up so that we can test our integration
+     */
+    return (
+      <Providers>
+        <App />
+      </Providers>
+    );
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof App>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+  parameters: {
+    tasks: [
+      { id: "1", text: "Task 1", ownerId: "user-1" },
+      { id: "2", text: "Task 2", ownerId: "user-1" },
+      { id: "3", text: "Task 3", ownerId: "user-2" },
+      { id: "4", text: "Task 4", ownerId: "user-2" },
+    ] satisfies Task[],
+    users: [
+      { id: "user-1", name: "User 1", profileImageUrl: "./src/user-1" },
+      { id: "user-2", name: "User 2", profileImageUrl: "./src/user-2" },
+    ] satisfies User[],
+  },
+};
+
+export const NoTasksNoUsers: Story = {
+  args: {},
+  parameters: {
+    tasks: [] satisfies Task[],
+    users: [] satisfies User[],
+  },
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.integration.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.integration.test.tsx
@@ -1,0 +1,304 @@
+import { QueryClient } from "@tanstack/query-core";
+import { render, screen, waitFor } from "@testing-library/react";
+import { App, AppDependencies } from "./App.view";
+import { Task, User } from "../../types";
+import userEvent from "@testing-library/user-event";
+import { createProviderTree } from "../../../../../lib/create-provider-tree";
+import {
+  CommandsContext,
+  CommandsContextInterface,
+  CommandsContextType,
+} from "../../providers/commands.provider";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { useAppViewModel } from "./App.view-model";
+import { Actions } from "../Actions/Actions.view";
+import { Filters } from "../Filters/Filters.view";
+import { TaskList } from "../TaskList/TaskList.view";
+import { useActionsViewModel } from "../Actions/Actions.view-model";
+import { useFiltersViewModel } from "../Filters/Filters.view-model";
+import { useTaskListViewModel } from "../TaskList/TaskList.view-model";
+import { ComponentProps } from "react";
+import { TaskItem } from "../TaskItem/TaskItem.view";
+import {
+  TaskItemViewModelProps,
+  useTaskItemViewModel,
+} from "../TaskItem/TaskItem.view-model";
+import {
+  createUserModel,
+  UserModelDependencies,
+} from "../../models/user.model";
+import { SelectedFiltersModel } from "../../models/selected-filters.model";
+import { UsersModel, UsersModelDependencies } from "../../models/users.model";
+import { TasksModel, TasksModelDependencies } from "../../models/tasks.model";
+import { ActionsDependencies } from "../Actions/Actions.view.dependencies";
+import { AppViewModelDependencies } from "./App.view-model.dependencies";
+import { TaskItemViewModelDependencies } from "../TaskItem/TaskItem.view-model.dependencies";
+import { TaskItemDependencies } from "../TaskItem/TaskItem.view.dependencies";
+import { TaskListDependencies } from "../TaskList/TaskList.view.dependencies";
+import { FiltersDependencies } from "../Filters/Filters.view.dependencies";
+
+describe("App Integration (only command layer mocked)", () => {
+  it("should reflect changes in filters in all applicable views", async () => {
+    // create query client for test
+    const queryClient = new QueryClient();
+
+    // create mock tasks
+    const mockTasks: Task[] = [
+      { id: "1", text: "Task 1", ownerId: "user-1" },
+      { id: "2", text: "Task 2", ownerId: "user-1" },
+      { id: "3", text: "Task 3", ownerId: "user-2" },
+      { id: "4", text: "Task 4", ownerId: "user-2" },
+    ];
+
+    // create mock users
+    const mockUsers: User[] = [
+      { id: "user-1", name: "User 1", profileImageUrl: "./src/user-1" },
+      { id: "user-2", name: "User 2", profileImageUrl: "./src/user-2" },
+    ];
+
+    // create mock commands
+    const commands: CommandsContextInterface = {
+      listTasksCommand: async () => mockTasks,
+      addTaskCommand: async () => ({
+        id: "1",
+        text: "task",
+        ownerId: "user-1",
+      }),
+      deleteTaskCommand: async () => {},
+      getUserCommand: async (userId) => {
+        return mockUsers.find((user) => user.id === userId);
+      },
+      listUsersCommand: async () => mockUsers,
+    };
+
+    /**
+     * Create provider tree
+     */
+    const Providers = createProviderTree([
+      <QueryClientProvider client={queryClient} />,
+      <CommandsContext.Provider value={commands} />,
+    ]);
+
+    /**
+     * Render a version that injects all the dependencies
+     * we created further up so that we can test our integration
+     */
+    render(
+      <Providers>
+        <App />
+      </Providers>,
+    );
+
+    // wait for loading to finish
+    await waitFor(() =>
+      expect(screen.queryByText(/Loading/)).not.toBeInTheDocument(),
+    );
+
+    // assert
+    expect(screen.getByText(/Task 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 3/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 4/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 4/)).toBeInTheDocument();
+
+    // act
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Owner:" }),
+      "User 1",
+    );
+
+    // assert
+    expect(screen.getByText(/Task 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 2/)).toBeInTheDocument();
+
+    // act
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Owner:" }),
+      "User 2",
+    );
+
+    // assert
+    expect(screen.getByText(/Task 3/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 4/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 2/)).toBeInTheDocument();
+
+    // act
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Owner:" }),
+      "All",
+    );
+
+    // assert
+    expect(screen.getByText(/Task 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 3/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 4/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 4/)).toBeInTheDocument();
+  });
+});
+
+describe("App Integration (all dependencies explicit)", () => {
+  it("should reflect changes in filters in all applicable views", async () => {
+    // create query client for test
+    const queryClient = new QueryClient();
+
+    // create mock tasks
+    const mockTasks: Task[] = [
+      { id: "1", text: "Task 1", ownerId: "user-1" },
+      { id: "2", text: "Task 2", ownerId: "user-1" },
+      { id: "3", text: "Task 3", ownerId: "user-2" },
+      { id: "4", text: "Task 4", ownerId: "user-2" },
+    ];
+
+    // create mock users
+    const mockUsers: User[] = [
+      { id: "user-1", name: "User 1", profileImageUrl: "./src/user-1" },
+      { id: "user-2", name: "User 2", profileImageUrl: "./src/user-2" },
+    ];
+
+    // Create tasks model dependencies
+    const tasksModelDependencies: TasksModelDependencies = {
+      listTasksCommand: async () => mockTasks,
+      addTaskCommand: async () => ({
+        id: "1",
+        text: "task",
+        ownerId: "user-1",
+      }),
+      deleteTaskCommand: async () => {},
+    };
+
+    // Create tasks model
+    const tasksModel = new TasksModel(queryClient, tasksModelDependencies);
+
+    // Create users model dependencies
+    const usersModelDependencies: UsersModelDependencies = {
+      listUsersCommand: async () => mockUsers,
+    };
+
+    // Create users model
+    const usersModel = new UsersModel(queryClient, usersModelDependencies);
+
+    // Create selected filters model
+    const selectedFiltersModel = new SelectedFiltersModel();
+
+    // Create dependencies for UserModel
+    const userModelDependencies: UserModelDependencies = {
+      getUserCommand: async (userId) => {
+        return mockUsers.find((user) => user.id === userId);
+      },
+    };
+
+    // Create dependencies for TaskItemViewModel
+    const taskItemViewModelDependencies: TaskItemViewModelDependencies = {
+      createUserModel: (userId) => {
+        return createUserModel(userId, queryClient, userModelDependencies);
+      },
+    };
+
+    // Create dependencies for TaskItem
+    const taskItemDependencies: TaskItemDependencies = {
+      useTaskItemViewModel: (props: TaskItemViewModelProps) =>
+        useTaskItemViewModel({
+          ...props,
+          dependencies: taskItemViewModelDependencies,
+        }),
+    };
+
+    // Create dependencies for TaskList
+    const taskListDependencies: TaskListDependencies = {
+      TaskItem: (props: ComponentProps<typeof TaskItem>) => (
+        <TaskItem {...props} dependencies={taskItemDependencies} />
+      ),
+      useTaskListViewModel,
+    };
+
+    // Create dependencies for Filters
+    const filtersDependencies: FiltersDependencies = {
+      useFiltersViewModel,
+    };
+
+    // Create dependencies for Actions
+    const actionsDependencies: ActionsDependencies = {
+      useActionsViewModel,
+    };
+
+    // Create app view model dependencies
+    const appViewModelDependencies: AppViewModelDependencies = {
+      createSelectedFiltersModel: () => selectedFiltersModel,
+      createTasksModel: () => tasksModel,
+      createUsersModel: () => usersModel,
+    };
+
+    // Create dependencies for Tasks
+    const appDependencies: AppDependencies = {
+      useAppViewModel: () =>
+        useAppViewModel({ dependencies: appViewModelDependencies }),
+      Actions: () => <Actions dependencies={actionsDependencies} />,
+      Filters: () => <Filters dependencies={filtersDependencies} />,
+      TaskList: () => <TaskList dependencies={taskListDependencies} />,
+    };
+
+    // Create fake commands to inject
+    const commands: CommandsContextType = {};
+
+    /**
+     * Render a version that injects all the dependencies
+     * we created further up so that we can test our integration
+     */
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CommandsContext.Provider value={commands}>
+          <App dependencies={appDependencies} />
+        </CommandsContext.Provider>
+      </QueryClientProvider>,
+    );
+
+    // wait for loading to finish
+    await waitFor(() =>
+      expect(screen.queryByText(/Loading/)).not.toBeInTheDocument(),
+    );
+
+    // assert
+    expect(screen.getByText(/Task 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 3/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 4/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 4/)).toBeInTheDocument();
+
+    // act
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Owner:" }),
+      "User 1",
+    );
+
+    // assert
+    expect(screen.getByText(/Task 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 2/)).toBeInTheDocument();
+
+    // act
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Owner:" }),
+      "User 2",
+    );
+
+    // assert
+    expect(screen.getByText(/Task 3/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 4/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 2/)).toBeInTheDocument();
+
+    // act
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Owner:" }),
+      "All",
+    );
+
+    // assert
+    expect(screen.getByText(/Task 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 3/)).toBeInTheDocument();
+    expect(screen.getByText(/Task 4/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 4/)).toBeInTheDocument();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.integration.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.integration.test.tsx
@@ -1,4 +1,3 @@
-import { QueryClient } from "@tanstack/query-core";
 import { render, screen, waitFor } from "@testing-library/react";
 import { App } from "./App.view";
 import { Task, User } from "../../types";
@@ -37,11 +36,12 @@ import { TaskItemDependencies } from "../TaskItem/TaskItem.view.dependencies";
 import { TaskListDependencies } from "../TaskList/TaskList.view.dependencies";
 import { FiltersDependencies } from "../Filters/Filters.view.dependencies";
 import { AppDependencies } from "./App.view.dependencies";
+import { createQueryClient } from "../../utils/create-query-client";
 
 describe("App Integration (only command layer mocked)", () => {
   it("should reflect changes in filters in all applicable views", async () => {
     // create query client for test
-    const queryClient = new QueryClient();
+    const queryClient = createQueryClient();
 
     // create mock tasks
     const mockTasks: Task[] = [
@@ -142,7 +142,7 @@ describe("App Integration (only command layer mocked)", () => {
 describe("App Integration (all dependencies explicit)", () => {
   it("should reflect changes in filters in all applicable views", async () => {
     // create query client for test
-    const queryClient = new QueryClient();
+    const queryClient = createQueryClient();
 
     // create mock tasks
     const mockTasks: Task[] = [

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.stories.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { App } from "./App.view";
+import { useAppViewModel } from "./App.view-model";
+
+const meta = {
+  component: App,
+  title: "App",
+  tags: ["autodocs"],
+} satisfies Meta<typeof App>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    dependencies: {
+      useAppViewModel: () => ({
+        models: {} as ReturnType<typeof useAppViewModel>["models"],
+      }),
+      Actions: () => <>Actions</>,
+      Filters: () => <>Filters</>,
+      TaskList: () => <>TaskList</>,
+    },
+  },
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { AppDependencies, App } from "./App.view";
+import { App } from "./App.view";
 import { useAppViewModel } from "./App.view-model";
+import { AppDependencies } from "./App.view.dependencies";
 
 /**
  * Remove the default dependencies from the test

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { AppDependencies, App } from "./App.view";
+import { useAppViewModel } from "./App.view-model";
+
+/**
+ * Remove the default dependencies from the test
+ * so that we avoid the unnecessary collect-time
+ */
+vi.mock("./Actions.view.dependencies", () => ({ default: {} }));
+
+describe("App", () => {
+  it("Renders correctly", () => {
+    // arrange
+    const dependencies: AppDependencies = {
+      useAppViewModel: () => ({
+        models: {} as ReturnType<typeof useAppViewModel>["models"],
+      }),
+      Actions: () => <div data-testid="Actions" />,
+      Filters: () => <div data-testid="Filters" />,
+      TaskList: () => <div data-testid="TaskList" />,
+    };
+
+    render(<App dependencies={dependencies} />);
+
+    // assert
+    expect(screen.getByTestId("Actions")).toBeInTheDocument();
+    expect(screen.getByTestId("Filters")).toBeInTheDocument();
+    expect(screen.getByTestId("TaskList")).toBeInTheDocument();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.tsx
@@ -1,15 +1,6 @@
 import { ModelsContext } from "../../providers/models.provider";
-import { Actions } from "../Actions/Actions.view";
-import { Filters } from "../Filters/Filters.view";
-import { TaskList } from "../TaskList/TaskList.view";
-import { useAppViewModel } from "./App.view-model";
-
-export type AppDependencies = {
-  useAppViewModel: typeof useAppViewModel;
-  Actions: typeof Actions;
-  Filters: typeof Filters;
-  TaskList: typeof TaskList;
-};
+import defaultDependencies from "./App.view.dependencies";
+import { AppDependencies } from "./App.view.dependencies";
 
 type Props = {
   dependencies?: AppDependencies;
@@ -22,14 +13,7 @@ type Props = {
  *
  * index.tsx should render the root only
  */
-export function App({
-  dependencies = {
-    useAppViewModel,
-    Actions,
-    Filters,
-    TaskList,
-  },
-}: Props) {
+export function App({ dependencies = defaultDependencies }: Props) {
   // Get dependencies
   const { useAppViewModel, Actions, Filters, TaskList } = dependencies;
 

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/App/App.view.tsx
@@ -1,0 +1,52 @@
+import { ModelsContext } from "../../providers/models.provider";
+import { Actions } from "../Actions/Actions.view";
+import { Filters } from "../Filters/Filters.view";
+import { TaskList } from "../TaskList/TaskList.view";
+import { useAppViewModel } from "./App.view-model";
+
+export type AppDependencies = {
+  useAppViewModel: typeof useAppViewModel;
+  Actions: typeof Actions;
+  Filters: typeof Filters;
+  TaskList: typeof TaskList;
+};
+
+type Props = {
+  dependencies?: AppDependencies;
+};
+
+/**
+ * TODO: Move this into the containers folder,
+ * and let the Root component live in the root folder instead
+ * (and also give it a view model)
+ *
+ * index.tsx should render the root only
+ */
+export function App({
+  dependencies = {
+    useAppViewModel,
+    Actions,
+    Filters,
+    TaskList,
+  },
+}: Props) {
+  // Get dependencies
+  const { useAppViewModel, Actions, Filters, TaskList } = dependencies;
+
+  /**
+   * The app view owns the tasks and users models,
+   * which is then provided via context for consumption
+   * futher down the tree.
+   */
+  const { models } = useAppViewModel();
+
+  return (
+    <ModelsContext.Provider value={models}>
+      <div>
+        <Actions />
+        <Filters />
+        <TaskList />
+      </div>
+    </ModelsContext.Provider>
+  );
+}

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view-model.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view-model.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook } from "@testing-library/react";
+import { ModelsDependencies, useFiltersViewModel } from "./Filters.view-model";
+import { signal } from "@preact/signals-core";
+import { ModelsContext } from "../../providers/models.provider";
+
+describe("useFiltersViewModel", () => {
+  it("should map domain models correctly to view model", async () => {
+    // arrange
+    const setSelectedOwnerId = vi.fn();
+
+    const mockModels: ModelsDependencies = {
+      usersModel: {
+        users: signal([]),
+      },
+      selectedFiltersModel: {
+        selectedOwnerId: signal(""),
+        setSelectedOwnerId,
+      },
+    };
+
+    const wrapper: React.FC<{
+      children?: React.ReactNode;
+    }> = ({ children }) => (
+      <ModelsContext.Provider value={mockModels}>
+        {children}
+      </ModelsContext.Provider>
+    );
+
+    const { result } = renderHook(() => useFiltersViewModel(), { wrapper });
+
+    expect(result.current).toEqual({
+      users: [],
+      selectedOwnerId: "",
+      setSelectedOwnerId,
+    });
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view-model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view-model.ts
@@ -1,0 +1,42 @@
+import { useSignalValue } from "../../../../../lib/use-signal-value";
+import { ISelectedFiltersModel } from "../../models/selected-filters.model";
+import { IUsersModel } from "../../models/users.model";
+import { useModels } from "../../providers/models.provider";
+
+/**
+ * The main purpose of this file is to
+ * bridge the business logic and the React view
+ *
+ * Access to business logic is facilitated
+ * by providing custom hooks with appropriate
+ * interfaces - taking care not to expose
+ * implementation details of the business
+ * logic itself or libraries used
+ *
+ * It can also be used for 3rd party library hooks,
+ * so that you avoid coupling your component directly.
+ * Instead you can provide a nice interface and map
+ * the custom hooks into it
+ */
+
+export interface ModelsDependencies {
+  usersModel: Pick<IUsersModel, "users">;
+  selectedFiltersModel: Pick<
+    ISelectedFiltersModel,
+    "selectedOwnerId" | "setSelectedOwnerId"
+  >;
+}
+
+export const useFiltersViewModel = () => {
+  // Get models from models provider
+  const models = useModels<ModelsDependencies>();
+
+  // Pull out the stuff we want from the shared models
+  const { usersModel, selectedFiltersModel } = models;
+
+  return {
+    users: useSignalValue(usersModel.users),
+    selectedOwnerId: useSignalValue(selectedFiltersModel.selectedOwnerId),
+    setSelectedOwnerId: selectedFiltersModel.setSelectedOwnerId,
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view.dependencies.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view.dependencies.ts
@@ -1,0 +1,17 @@
+import { useFiltersViewModel } from "./Filters.view-model";
+
+/**
+ * This file contains the interface of the
+ * dependencies for the unit, in addition
+ * to the defaults for those dependencies
+ */
+
+export type FiltersDependencies = {
+  useFiltersViewModel: typeof useFiltersViewModel;
+};
+
+const defaultDependencies: FiltersDependencies = {
+  useFiltersViewModel,
+};
+
+export default defaultDependencies;

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view.stories.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view.stories.tsx
@@ -1,0 +1,59 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Filters } from "./Filters.view";
+
+const meta = {
+  component: Filters,
+  title: "Filters",
+  tags: ["autodocs"],
+} satisfies Meta<typeof Filters>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const NoFilterOptions: Story = {
+  args: {
+    dependencies: {
+      useFiltersViewModel: () => ({
+        users: [],
+        selectedOwnerId: "",
+        setSelectedOwnerId: async () => {},
+      }),
+    },
+  },
+};
+
+export const NoFilterSelected: Story = {
+  args: {
+    dependencies: {
+      useFiltersViewModel: () => ({
+        users: [],
+        selectedOwnerId: "",
+        setSelectedOwnerId: async () => {},
+      }),
+    },
+  },
+};
+
+export const UserFilterSelected: Story = {
+  args: {
+    dependencies: {
+      useFiltersViewModel: () => ({
+        users: [
+          {
+            id: "user-1",
+            name: "John Doe",
+            profileImageUrl: "./src/test.png",
+          },
+          {
+            id: "user-2",
+            name: "Jane Doe",
+            profileImageUrl: "./src/test-2.png",
+          },
+        ],
+        selectedOwnerId: "user-1",
+        setSelectedOwnerId: async () => {},
+      }),
+    },
+  },
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Filters } from "./Filters.view";
+import { FiltersDependencies } from "./Filters.view.dependencies";
+
+/**
+ * Remove the default dependencies from the test
+ * so that we avoid the unnecessary collect-time
+ */
+vi.mock("./Filters.view.dependencies", () => ({ default: {} }));
+
+describe("Filters Component", () => {
+  it("Renders correctly", () => {
+    // arrange
+    const dependencies: FiltersDependencies = {
+      useFiltersViewModel: vi.fn(() => ({
+        users: [
+          {
+            id: "user-1",
+            name: "John Doe",
+            profileImageUrl: "./src/test.png",
+          },
+          {
+            id: "user-2",
+            name: "Jane Doe",
+            profileImageUrl: "./src/test-2.png",
+          },
+        ],
+        selectedOwnerId: "user-1",
+        setSelectedOwnerId: vi.fn(),
+      })),
+    };
+
+    render(<Filters dependencies={dependencies} />);
+
+    // assert
+    expect(screen.getByText("Filters")).toBeInTheDocument();
+    expect(screen.getByText(/John Doe/)).toBeInTheDocument();
+    expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
+  });
+
+  it("Calls correct handler with correct arguments when selecting an owner", async () => {
+    // arrange
+    const setSelectedOwnerId = vi.fn();
+
+    const dependencies: FiltersDependencies = {
+      useFiltersViewModel: vi.fn(() => ({
+        users: [
+          {
+            id: "user-1",
+            name: "John Doe",
+            profileImageUrl: "./src/test.png",
+          },
+          {
+            id: "user-2",
+            name: "Jane Doe",
+            profileImageUrl: "./src/test-2.png",
+          },
+        ],
+        selectedOwnerId: "",
+        setSelectedOwnerId,
+      })),
+    };
+
+    render(<Filters dependencies={dependencies} />);
+
+    // assert
+    expect(screen.getByText("Filters")).toBeInTheDocument();
+    expect(screen.getByText(/John Doe/)).toBeInTheDocument();
+    expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
+
+    // act
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Owner:" }),
+      "John Doe",
+    );
+
+    // assert
+    expect(setSelectedOwnerId).toHaveBeenCalledWith("user-1");
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/Filters/Filters.view.tsx
@@ -1,0 +1,52 @@
+import { useCallback } from "react";
+import defaultDependencies, {
+  FiltersDependencies,
+} from "./Filters.view.dependencies";
+
+type Props = {
+  dependencies?: FiltersDependencies;
+};
+
+export function Filters({ dependencies = defaultDependencies }: Props) {
+  // Get dependencies
+  const { useFiltersViewModel } = dependencies;
+
+  // Use view model
+  const {
+    setSelectedOwnerId,
+    selectedOwnerId,
+    users = [],
+  } = useFiltersViewModel();
+
+  const handleChangeSelectedUser = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedOwnerId(event.target.value);
+    },
+    [setSelectedOwnerId],
+  );
+
+  const userOptions = [
+    <option key={"all"} value={""}>
+      All
+    </option>,
+    ...users.map((user) => (
+      <option key={user.id} value={user.id}>
+        {user.name}
+      </option>
+    )),
+  ];
+
+  return (
+    <div>
+      <h3>Filters</h3>
+      <div>
+        <label>
+          Owner:
+          <select value={selectedOwnerId} onChange={handleChangeSelectedUser}>
+            {userOptions}
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view-model.dependencies.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view-model.dependencies.ts
@@ -1,0 +1,19 @@
+import { createUserModel, IUserModel } from "../../models/user.model";
+
+/**
+ * This file contains the interface of the
+ * dependencies for the unit, in addition
+ * to the defaults for those dependencies
+ */
+
+export type TaskItemViewModelDependencies = {
+  createUserModel: (
+    ...args: Parameters<typeof createUserModel>
+  ) => Pick<IUserModel, "user">;
+};
+
+const defaultDependencies: TaskItemViewModelDependencies = {
+  createUserModel,
+};
+
+export default defaultDependencies;

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view-model.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view-model.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook, act } from "@testing-library/react";
+import {
+  CommandsDependencies,
+  ModelsDependencies,
+  useTaskItemViewModel,
+} from "./TaskItem.view-model";
+import { signal } from "@preact/signals-core";
+import { Task } from "../../types";
+import { ModelsContext } from "../../providers/models.provider";
+import { CommandsContext } from "../../providers/commands.provider";
+import { QueryClient } from "@tanstack/query-core";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { TaskItemViewModelDependencies } from "./TaskItem.view-model.dependencies";
+
+/**
+ * Remove the default dependencies from the test
+ * so that we avoid the unnecessary collect-time
+ */
+vi.mock("./TaskItem.view-model.dependencies", () => ({ default: {} }));
+
+describe("useTaskItemViewModel", () => {
+  it("should map domain models correctly to view model", async () => {
+    // arrange
+    const deleteTask = vi.fn();
+
+    const queryClient = new QueryClient();
+
+    const dependencies: TaskItemViewModelDependencies = {
+      createUserModel: () => ({
+        user: signal({
+          id: "user-1",
+          name: "John Doe",
+          profileImageUrl: "./src/image.png",
+        }),
+      }),
+    };
+
+    const mockCommands: CommandsDependencies = {
+      getUserCommand: vi.fn(),
+    };
+
+    const mockModels: ModelsDependencies = {
+      tasksModel: {
+        deleteTask,
+      },
+    };
+
+    const task: Task = {
+      id: "1",
+      text: "Buy milk",
+      ownerId: "user-1",
+    };
+
+    const wrapper: React.FC<{
+      children?: React.ReactNode;
+    }> = ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        <CommandsContext.Provider value={mockCommands}>
+          <ModelsContext.Provider value={mockModels}>
+            {children}
+          </ModelsContext.Provider>
+        </CommandsContext.Provider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () => useTaskItemViewModel({ dependencies, task }),
+      { wrapper },
+    );
+
+    // assert
+    expect(result.current.user).toEqual({
+      id: "user-1",
+      name: "John Doe",
+      profileImageUrl: "./src/image.png",
+    });
+
+    // call delete handler
+    await act(() => result.current.deleteTask());
+
+    // assert
+    expect(deleteTask).toBeCalledWith(task.id);
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view-model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view-model.ts
@@ -1,0 +1,77 @@
+import { useCallback, useMemo } from "react";
+import { useSignalValue } from "../../../../../lib/use-signal-value";
+import { Task } from "../../types";
+import { ITasksModel } from "../../models/tasks.model";
+import { useModels } from "../../providers/models.provider";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCommands } from "../../providers/commands.provider";
+import { IGetUserCommandInvocation } from "../../commands/get-user.command";
+import defaultDependencies, {
+  TaskItemViewModelDependencies,
+} from "./TaskItem.view-model.dependencies";
+
+/**
+ * The main purpose of this file is to
+ * bridge the business logic and the React view
+ *
+ * Access to business logic is facilitated
+ * by providing custom hooks with appropriate
+ * interfaces - taking care not to expose
+ * implementation details of the business
+ * logic itself or libraries used
+ *
+ * It can also be used for 3rd party library hooks,
+ * so that you avoid coupling your component directly.
+ * Instead you can provide a nice interface and map
+ * the custom hooks into it
+ */
+
+export type TaskItemViewModelProps = {
+  dependencies?: TaskItemViewModelDependencies;
+  task: Task;
+};
+
+export interface ModelsDependencies {
+  tasksModel: Pick<ITasksModel, "deleteTask">;
+}
+
+export interface CommandsDependencies {
+  getUserCommand: IGetUserCommandInvocation;
+}
+
+export const useTaskItemViewModel = ({
+  dependencies = defaultDependencies,
+  task,
+}: TaskItemViewModelProps) => {
+  // Get dependencies
+  const { createUserModel } = dependencies;
+
+  // Get commands from the shared command provider
+  const commands = useCommands<CommandsDependencies>();
+
+  // Get models from the shared models provider
+  const models = useModels<ModelsDependencies>();
+
+  // Get the query client
+  const queryClient = useQueryClient();
+
+  // Pull out the stuff we want from the shared models
+  const { tasksModel } = models;
+
+  // Pull out the stuff we need from the shared commands
+  const { getUserCommand } = commands;
+
+  const userModel = useMemo(
+    () => createUserModel(task.ownerId, queryClient, { getUserCommand }),
+    [createUserModel, getUserCommand, queryClient, task.ownerId],
+  );
+
+  const deleteTask = useCallback(() => {
+    return tasksModel.deleteTask(task.id);
+  }, [task.id, tasksModel]);
+
+  return {
+    user: useSignalValue(userModel.user),
+    deleteTask,
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view.dependencies.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view.dependencies.ts
@@ -1,0 +1,17 @@
+import { useTaskItemViewModel } from "./TaskItem.view-model";
+
+/**
+ * This file contains the interface of the
+ * dependencies for the unit, in addition
+ * to the defaults for those dependencies
+ */
+
+export type TaskItemDependencies = {
+  useTaskItemViewModel: typeof useTaskItemViewModel;
+};
+
+const defaultDependencies: TaskItemDependencies = {
+  useTaskItemViewModel,
+};
+
+export default defaultDependencies;

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view.stories.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view.stories.tsx
@@ -1,0 +1,64 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { TaskItem } from "./TaskItem.view";
+
+const meta = {
+  component: TaskItem,
+  title: "TaskItem",
+  tags: ["autodocs"],
+} satisfies Meta<typeof TaskItem>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const EmptyTask: Story = {
+  args: {
+    dependencies: {
+      useTaskItemViewModel: () => ({
+        user: undefined,
+        deleteTask: async () => {},
+      }),
+    },
+    task: {
+      id: "",
+      text: "",
+      ownerId: "",
+    },
+  },
+};
+
+export const LoadingUser: Story = {
+  args: {
+    task: {
+      id: "1",
+      text: "Task 1",
+      ownerId: "user-1",
+    },
+    dependencies: {
+      useTaskItemViewModel: () => ({
+        user: undefined,
+        deleteTask: async () => {},
+      }),
+    },
+  },
+};
+
+export const LoadedUser: Story = {
+  args: {
+    task: {
+      id: "1",
+      text: "Task 1",
+      ownerId: "user-1",
+    },
+    dependencies: {
+      useTaskItemViewModel: () => ({
+        user: {
+          id: "user-1",
+          name: "John Doe",
+          profileImageUrl: "./src/abc.jpg",
+        },
+        deleteTask: async () => {},
+      }),
+    },
+  },
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { TaskItem } from "./TaskItem.view";
+import { Task } from "../../types";
+import userEvent from "@testing-library/user-event";
+import { TaskItemDependencies } from "./TaskItem.view.dependencies";
+
+/**
+ * Remove the default dependencies from the test
+ * so that we avoid the unnecessary collect-time
+ */
+vi.mock("./TaskItem.view.dependencies", () => ({ default: {} }));
+
+describe("TaskItem", () => {
+  it("Renders correctly when user is loaded", () => {
+    // arrange
+    const task: Task = {
+      id: "test",
+      text: "Write self reflection",
+      ownerId: "user-1",
+    };
+
+    const taskItemDependencies: TaskItemDependencies = {
+      useTaskItemViewModel: () => ({
+        user: {
+          id: "user-1",
+          name: "John Doe",
+          profileImageUrl: "./src/profile.png",
+        },
+        deleteTask: vi.fn(),
+      }),
+    };
+
+    render(<TaskItem dependencies={taskItemDependencies} task={task} />);
+
+    // assert
+    expect(screen.getByText(/Write self reflection/)).toBeInTheDocument();
+    expect(screen.getByText(/John Doe/)).toBeInTheDocument();
+  });
+
+  it("Renders correctly when loading", () => {
+    // arrange
+    const task: Task = {
+      id: "test",
+      text: "Write self reflection",
+      ownerId: "user-1",
+    };
+
+    const taskItemDependencies: TaskItemDependencies = {
+      useTaskItemViewModel: () => ({
+        user: undefined,
+        deleteTask: vi.fn(),
+      }),
+    };
+
+    render(<TaskItem dependencies={taskItemDependencies} task={task} />);
+
+    // assert
+    expect(screen.getByText(/Write self reflection/)).toBeInTheDocument();
+    expect(screen.getByText(/loading user/)).toBeInTheDocument();
+  });
+
+  it("Calls delete handler with correct arguments", async () => {
+    // arrange
+    const deleteTask = vi.fn();
+
+    const task: Task = {
+      id: "test",
+      text: "Write self reflection",
+      ownerId: "user-1",
+    };
+
+    const taskItemDependencies: TaskItemDependencies = {
+      useTaskItemViewModel: () => ({
+        user: {
+          id: "user-1",
+          name: "John Doe",
+          profileImageUrl: "./src/profile.png",
+        },
+        deleteTask,
+      }),
+    };
+
+    render(<TaskItem dependencies={taskItemDependencies} task={task} />);
+
+    // act
+    await userEvent.click(screen.getByRole("button", { name: "X" }));
+
+    // assert
+    expect(deleteTask).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskItem/TaskItem.view.tsx
@@ -1,0 +1,23 @@
+import { Task } from "../../types";
+import defaultDependencies, {
+  TaskItemDependencies,
+} from "./TaskItem.view.dependencies";
+
+type Props = {
+  dependencies?: TaskItemDependencies;
+  task: Task;
+};
+
+export function TaskItem({ dependencies = defaultDependencies, task }: Props) {
+  // Get dependencies
+  const { useTaskItemViewModel } = dependencies;
+
+  const { user, deleteTask } = useTaskItemViewModel({ task });
+
+  return (
+    <li>
+      {task.text} {user?.name || "loading user..."}{" "}
+      <button onClick={deleteTask}>X</button>
+    </li>
+  );
+}

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view-model.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view-model.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react";
+import { ModelDependencies, useTaskListViewModel } from "./TaskList.view-model";
+import { signal } from "@preact/signals-core";
+import { Task } from "../../types";
+import { ModelsContext } from "../../providers/models.provider";
+
+describe("useTaskListViewModel", () => {
+  it("should map domain models correctly to view model", async () => {
+    const mockTaskList: Task[] = [];
+    const mockTaskListCount = 0;
+
+    // arrange
+    const mockModels: ModelDependencies = {
+      tasksModel: {
+        getTasksByOwnerId: vi.fn(() => signal(mockTaskList)),
+        getTasksCountByOwnerId: vi.fn(() => signal(mockTaskListCount)),
+        addTask: vi.fn(),
+        isFetching: signal(false),
+        isLoading: signal(false),
+        isSaving: signal(false),
+      },
+      selectedFiltersModel: {
+        selectedOwnerId: signal(""),
+        setSelectedOwnerId: vi.fn(),
+      },
+    };
+
+    const wrapper: React.FC<{
+      children?: React.ReactNode;
+    }> = ({ children }) => (
+      <ModelsContext.Provider value={mockModels}>
+        {children}
+      </ModelsContext.Provider>
+    );
+
+    const { result } = renderHook(() => useTaskListViewModel(), { wrapper });
+
+    // assert
+    expect(result.current).toEqual({
+      tasks: [],
+      tasksCount: 0,
+      isLoading: false,
+      isFetching: false,
+      isSaving: false,
+      addTask: mockModels.tasksModel?.addTask,
+    });
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view-model.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view-model.ts
@@ -1,0 +1,54 @@
+import { useSignalValue } from "../../../../../lib/use-signal-value";
+import { ITasksModel } from "../../models/tasks.model";
+import { ISelectedFiltersModel } from "../../models/selected-filters.model";
+import { useModels } from "../../providers/models.provider";
+
+/**
+ * The main purpose of this file is to
+ * bridge the business logic and the React view
+ *
+ * Access to business logic is facilitated
+ * by providing custom hooks with appropriate
+ * interfaces - taking care not to expose
+ * implementation details of the business
+ * logic itself or libraries used
+ *
+ * It can also be used for 3rd party library hooks,
+ * so that you avoid coupling your component directly.
+ * Instead you can provide a nice interface and map
+ * the custom hooks into it
+ */
+
+export type ModelDependencies = {
+  selectedFiltersModel: ISelectedFiltersModel;
+  tasksModel: Pick<
+    ITasksModel,
+    | "getTasksByOwnerId"
+    | "getTasksCountByOwnerId"
+    | "addTask"
+    | "isFetching"
+    | "isLoading"
+    | "isSaving"
+  >;
+};
+
+export const useTaskListViewModel = () => {
+  // Get models from the shared models provider
+  const models = useModels<ModelDependencies>();
+
+  // Pull out what we need from the models
+  const { tasksModel, selectedFiltersModel } = models;
+
+  return {
+    tasks: useSignalValue(
+      tasksModel.getTasksByOwnerId(selectedFiltersModel.selectedOwnerId),
+    ),
+    tasksCount: useSignalValue(
+      tasksModel.getTasksCountByOwnerId(selectedFiltersModel.selectedOwnerId),
+    ),
+    isLoading: useSignalValue(tasksModel.isLoading),
+    isFetching: useSignalValue(tasksModel.isFetching),
+    isSaving: useSignalValue(tasksModel.isSaving),
+    addTask: tasksModel.addTask,
+  };
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view.dependencies.ts
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view.dependencies.ts
@@ -1,0 +1,20 @@
+import { useTaskListViewModel } from "./TaskList.view-model";
+import { TaskItem } from "../TaskItem/TaskItem.view";
+
+/**
+ * This file contains the interface of the
+ * dependencies for the unit, in addition
+ * to the defaults for those dependencies
+ */
+
+export type TaskListDependencies = {
+  useTaskListViewModel: typeof useTaskListViewModel;
+  TaskItem: typeof TaskItem;
+};
+
+const defaultDependencies: TaskListDependencies = {
+  useTaskListViewModel,
+  TaskItem,
+};
+
+export default defaultDependencies;

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view.stories.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view.stories.tsx
@@ -1,0 +1,101 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { TaskList } from "./TaskList.view";
+
+const meta = {
+  component: TaskList,
+  title: "TaskList",
+  tags: ["autodocs"],
+} satisfies Meta<typeof TaskList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {
+  args: {
+    dependencies: {
+      useTaskListViewModel: () => ({
+        tasks: [],
+        tasksCount: 0,
+        addTask: async () => {},
+        isLoading: true,
+        isSaving: false,
+        isFetching: false,
+      }),
+      TaskItem: ({ task }) => <li>{task.text}</li>,
+    },
+  },
+};
+
+export const EmptyList: Story = {
+  args: {
+    dependencies: {
+      useTaskListViewModel: () => ({
+        tasks: [],
+        tasksCount: 0,
+        addTask: async () => {},
+        isLoading: false,
+        isSaving: false,
+        isFetching: false,
+      }),
+      TaskItem: ({ task }) => <li>{task.text}</li>,
+    },
+  },
+};
+
+export const WithTasks: Story = {
+  args: {
+    dependencies: {
+      useTaskListViewModel: () => ({
+        tasks: [
+          { id: "1", text: "Buy milk", ownerId: "user-1" },
+          { id: "2", text: "Paint house", ownerId: "user-1" },
+        ],
+        tasksCount: 2,
+        addTask: async () => {},
+        isLoading: false,
+        isSaving: false,
+        isFetching: false,
+      }),
+      TaskItem: ({ task }) => <li>{task.text}</li>,
+    },
+  },
+};
+
+export const Saving: Story = {
+  args: {
+    dependencies: {
+      useTaskListViewModel: () => ({
+        tasks: [
+          { id: "1", text: "Buy milk", ownerId: "user-1" },
+          { id: "2", text: "Paint house", ownerId: "user-1" },
+        ],
+        tasksCount: 2,
+        addTask: async () => {},
+        isLoading: true,
+        isSaving: true,
+        isFetching: false,
+      }),
+      TaskItem: ({ task }) => <li>{task.text}</li>,
+    },
+  },
+};
+
+export const Refetching: Story = {
+  args: {
+    dependencies: {
+      useTaskListViewModel: () => ({
+        tasks: [
+          { id: "1", text: "Buy milk", ownerId: "user-1" },
+          { id: "2", text: "Paint house", ownerId: "user-1" },
+        ],
+        tasksCount: 2,
+        addTask: async () => {},
+        isLoading: false,
+        isSaving: false,
+        isFetching: true,
+      }),
+      TaskItem: ({ task }) => <li>{task.text}</li>,
+    },
+  },
+};

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view.test.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { TaskList } from "./TaskList.view";
+import { TaskListDependencies } from "./TaskList.view.dependencies";
+
+/**
+ * Remove the default dependencies from the test
+ * so that we avoid the unnecessary collect-time
+ */
+vi.mock("./TaskList.view.dependencies", () => ({ default: {} }));
+
+describe("TaskList Component", () => {
+  it("Renders correctly when loading", () => {
+    // arrange
+    const dependencies: TaskListDependencies = {
+      useTaskListViewModel: vi.fn(() => ({
+        tasks: [],
+        tasksCount: 0,
+        isLoading: true,
+        isFetching: false,
+        isSaving: false,
+        addTask: vi.fn(),
+      })),
+      TaskItem: () => <></>,
+    };
+
+    render(<TaskList dependencies={dependencies} />);
+
+    // assert
+    expect(screen.getByText(/Loading/)).toBeInTheDocument();
+  });
+
+  it("Renders correctly when saving and refetching", () => {
+    // arrange
+    const dependencies: TaskListDependencies = {
+      useTaskListViewModel: vi.fn(() => ({
+        tasks: [],
+        tasksCount: 0,
+        isLoading: false,
+        isFetching: true,
+        isSaving: true,
+        addTask: vi.fn(),
+      })),
+      TaskItem: () => <></>,
+    };
+
+    render(<TaskList dependencies={dependencies} />);
+
+    // assert
+    expect(screen.getByText(/saving/)).toBeInTheDocument();
+    expect(screen.getByText(/wait/)).toBeInTheDocument();
+  });
+
+  it("Renders correctly with no tasks", () => {
+    // arrange
+    const dependencies: TaskListDependencies = {
+      useTaskListViewModel: vi.fn(() => ({
+        tasks: [],
+        tasksCount: 0,
+        isLoading: false,
+        isFetching: false,
+        isSaving: false,
+        addTask: vi.fn(),
+      })),
+      TaskItem: () => <></>,
+    };
+
+    render(<TaskList dependencies={dependencies} />);
+
+    // assert
+    expect(screen.getByText("Tasks")).toBeInTheDocument();
+  });
+
+  it("Renders correctly with multiple tasks", () => {
+    // arrange
+    const dependencies: TaskListDependencies = {
+      useTaskListViewModel: vi.fn(() => ({
+        tasks: [
+          {
+            id: "1",
+            text: "Task 1",
+            ownerId: "user-1",
+          },
+          {
+            id: "2",
+            text: "Task 2",
+            ownerId: "user-1",
+          },
+        ],
+        tasksCount: 2,
+        isLoading: false,
+        isFetching: false,
+        isSaving: false,
+        addTask: vi.fn(),
+      })),
+      TaskItem: () => <div>TaskItem</div>,
+    };
+
+    render(<TaskList dependencies={dependencies} />);
+
+    // assert
+    expect(screen.getAllByText("TaskItem").length).toEqual(2);
+    expect(screen.getByText(/2/)).toBeInTheDocument();
+  });
+});

--- a/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view.tsx
+++ b/src/features/signals-mvvm-commands/TasksPropDrillingDiContainersOptimized/views/TaskList/TaskList.view.tsx
@@ -1,0 +1,40 @@
+import defaultDependencies, {
+  TaskListDependencies,
+} from "./TaskList.view.dependencies";
+
+type Props = {
+  dependencies?: TaskListDependencies;
+};
+
+export function TaskList({ dependencies = defaultDependencies }: Props) {
+  // Get dependencies
+  const { useTaskListViewModel, TaskItem } = dependencies;
+
+  // Use the view model (state and commands)
+  const {
+    tasks = [],
+    tasksCount,
+    isLoading,
+    isFetching,
+    isSaving,
+  } = useTaskListViewModel();
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  const taskElements = tasks.map((task) => (
+    <TaskItem key={task.id} task={task}></TaskItem>
+  ));
+
+  return (
+    <div>
+      <h3>
+        Tasks <span>{isSaving && "(saving...)"}</span>
+      </h3>
+      <h4>Count: {tasksCount}</h4>
+      <ul>{taskElements}</ul>
+      {isFetching && <div>wait...</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
By moving the dependency interface + default dependencies to a separate file we can avoid the unnecessary collect-time by using `vi.mock` during the test. The types will still be imported as expected though, since those are provided during a different part of the process.